### PR TITLE
update .gitignore to add Mac OS .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.DS_Store
 /output
 /qa
 /temp


### PR DESCRIPTION
The Mac OS automatically creates filesystem metadata in hidden .DS_Store files one per directory; this .gitignore change keeps those from being false positives in git status etc.