### PR TITLE
newly rewritten CCS+BCS+COL measures for HEDIS 2018

### DIFF
--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -1,0 +1,171 @@
+/*
+Breast Cancer Screening (BCS)
+*/
+
+library BCS_FHIR version '1.0.0'
+
+//using FHIR version '3.0.1'
+using FHIR version '3.0.0'
+
+/*
+Description
+The percentage of women 50–74 years of age who had a mammogram to screen for breast cancer.
+*/
+
+valueset "Mammography Value Set": 'TODO'
+
+valueset "Bilateral Mastectomy Value Set": 'TODO'
+valueset "Bilateral Modifier Value Set": 'TODO'
+valueset "History of Bilateral Mastectomy Value Set": 'TODO'
+valueset "Unilateral Mastectomy Value Set": 'TODO'
+
+valueset "Absence of Left Breast Value Set": 'TODO'
+valueset "Left Modifier Value Set": 'TODO'
+valueset "Unilateral Mastectomy Left Value Set": 'TODO'
+
+valueset "Absence of Right Breast Value Set": 'TODO'
+valueset "Right Modifier Value Set": 'TODO'
+valueset "Unilateral Mastectomy Right Value Set": 'TODO'
+
+/*
+This library has a single explicit parameter which is the measurement year.
+While the actual parameter's type accepts all intervals, this library
+expects it will only be given arguments corresponding exactly to one whole
+calendar year, and it will not behave properly otherwise; 2015 for example:
+Interval[DateTime(2015,1,1,0,0,0,0), DateTime(2016,1,1,0,0,0,0))
+*/
+
+parameter "Measurement Period" Interval<DateTime>
+
+define "Lookback Interval 27 More Months":
+	Interval[start of "Measurement Period" - 27 months, end of "Measurement Period")
+
+/*
+This library evaluates with respect to exactly 1 candidate patient at a time,
+that patient being given by the special context parameter Patient.
+*/
+
+context Patient
+
+/*
+Eligible Population
+Product lines -- Commercial, Medicaid, Medicare (report each product line separately).
+*/
+
+define "Is In Eligible Population":
+	"Is Female"
+		and "Is Age 52 to 74 at End"
+		and (not "Is In Hospice")
+
+define "Is Female":
+	Patient.gender.value = 'female'
+
+define "Is Age 52 to 74 at End":
+	AgeInYearsAt(end of "Measurement Period") between 52 and 74
+
+define "Is In Hospice":
+	false
+	// TODO: Determine properly whether the patient was in hospice during the measurement year.
+
+define "Is In Eligible Population Commercial":
+	"Is In Eligible Population"
+		and "Is Continuous Enrollment Commercial"
+
+define "Is Continuous Enrollment Commercial":
+	true
+	// TODO: Determine continuous enrollment over the 39 month period consisting
+	// of the measurement year plus the 2 prior years plus the 3 prior months.
+	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period. 
+	// Allowable gap -- No more than one gap in enrollment of up to 45 days
+	// for each full calendar year of continuous enrollment (i.e., the
+	// measurement year and the year prior to the measurement year).
+	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
+	// marked as a stub / draft / incomplete.
+
+define "Is In Eligible Population Medicaid":
+	"Is In Eligible Population"
+		and "Is Continuous Enrollment Medicaid"
+
+define "Is Continuous Enrollment Medicaid":
+	true
+	// TODO: Determine continuous enrollment over the 39 month period consisting
+	// of the measurement year plus the 2 prior years plus the 3 prior months.
+	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period. 
+	// Allowable gap -- No more than one gap in enrollment of up to 45 days
+	// for each full calendar year of continuous enrollment (i.e., the
+	// measurement year and the year prior to the measurement year).
+	// To determine continuous enrollment for a Medicaid beneficiary for
+	// whom enrollment is verified monthly, the member may not have more
+	// than a 1-month gap in coverage during each full calendar year of
+	// continuous enrollment (i.e., the measurement year and the year prior
+	// to the measurement year).
+	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
+	// marked as a stub / draft / incomplete.
+
+define "Is In Eligible Population Medicare":
+	"Is In Eligible Population"
+		and "Is Continuous Enrollment Medicare"
+		and (if "Is Age 65 Plus at Start"
+			then ("Is Enrolled in Institutional SNP"
+				or "Is Living Long-Term in Institution")
+			else false)
+
+define "Is Continuous Enrollment Medicare":
+	true
+	// TODO: Determine continuous enrollment over the 39 month period consisting
+	// of the measurement year plus the 2 prior years plus the 3 prior months.
+	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period. 
+	// Allowable gap -- No more than one gap in enrollment of up to 45 days
+	// for each full calendar year of continuous enrollment (i.e., the
+	// measurement year and the year prior to the measurement year).
+	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
+	// marked as a stub / draft / incomplete.
+
+define "Is Age 65 Plus at Start":
+	AgeInYearsAt(start of "Measurement Period") >= 65
+
+define "Is Enrolled in Institutional SNP":
+	false
+	// TODO: Determine properly whether the patient was in SNP during the measurement year.
+
+define "Is Living Long-Term in Institution":
+	false
+	// TODO: Determine properly whether the patient was in LTI during the measurement year.
+
+/*
+Administrative Specification
+*/
+
+define "Is In Denominator":
+	"Is In Eligible Population"
+
+define "Is In Numerator":
+	"Is In Eligible Population"
+		and "Is Mammogram In Last 39 Months"
+
+define "Is Mammogram In Last 39 Months":
+	exists(
+		"Dates of Mammograms" WhenM
+			where (WhenM as dateTime).value during "Lookback Interval 27 More Months"
+	)
+
+define "Dates of Mammograms":
+	([Procedure: "Mammography Value Set"] Proc
+		where Proc.status.value = 'completed'
+		return Proc.performed)
+	union
+	([DiagnosticReport: "Mammography Value Set"] DiagRep
+		where DiagRep.status.value = 'final'
+		return DiagRep.effective)
+	union
+	([Observation: "Mammography Value Set"] Obs
+		where Obs.status.value in { 'final', 'amended' }
+		return Obs.effective)
+	// TODO: Is this only a Procedure or could it alternately be a DiagnosticReport or Observation etc?
+
+define "Is In Administrative Exclusions":
+	"Is Bilateral Mastectomy"
+
+define "Is Bilateral Mastectomy":
+	false
+	// TODO: Enumerate the specified alternative criteria for this.

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -147,7 +147,7 @@ define "Is Mammogram In Last 39 Months":
 	exists(
 		[Procedure: "Mammography Value Set"] Proc
 			where Proc.status.value = 'completed'
-				and (Proc.performed as dateTime).value during "Lookback Interval 27 More Months"
+				and IncludedIn(ChoiceToIntervalOfDT(Proc.performed), "Lookback Interval 27 More Months")
 	)
 
 define "Is In Administrative Exclusions":
@@ -156,3 +156,14 @@ define "Is In Administrative Exclusions":
 define "Is Bilateral Mastectomy":
 	false
 	// TODO: Enumerate the specified alternative criteria for this.
+
+
+/*
+Utility Functions
+*/
+
+define function ChoiceToIntervalOfDT(value Choice<FHIR.dateTime, FHIR.Period>):
+	if value is FHIR.dateTime then
+		Interval[value.value, value.value]
+	else
+		Interval[value."start".value, value."end".value]

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -145,23 +145,10 @@ define "Is In Numerator":
 
 define "Is Mammogram In Last 39 Months":
 	exists(
-		"Dates of Mammograms" WhenM
-			where (WhenM as dateTime).value during "Lookback Interval 27 More Months"
+		[Procedure: "Mammography Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and (Proc.performed as dateTime).value during "Lookback Interval 27 More Months"
 	)
-
-define "Dates of Mammograms":
-	([Procedure: "Mammography Value Set"] Proc
-		where Proc.status.value = 'completed'
-		return Proc.performed)
-	union
-	([DiagnosticReport: "Mammography Value Set"] DiagRep
-		where DiagRep.status.value = 'final'
-		return DiagRep.effective)
-	union
-	([Observation: "Mammography Value Set"] Obs
-		where Obs.status.value in { 'final', 'amended' }
-		return Obs.effective)
-	// TODO: Is this only a Procedure or could it alternately be a DiagnosticReport or Observation etc?
 
 define "Is In Administrative Exclusions":
 	"Is Bilateral Mastectomy"

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -130,7 +130,7 @@ define "Dates of Cervical Cytology Tests":
 		return Proc.performed)
 	union
 	([DiagnosticReport: "Cervical Cytology Value Set"] DiagRep
-		where DiagRep.status.value = 'final'
+		where DiagRep.status.value in { 'final', 'appended', 'corrected' }
 		return DiagRep.effective)
 	union
 	([Observation: "Cervical Cytology Value Set"] Obs
@@ -143,7 +143,7 @@ define "Dates of HPV Tests":
 		return Proc.performed)
 	union
 	([DiagnosticReport: "HPV Tests Value Set"] DiagRep
-		where DiagRep.status.value = 'final'
+		where DiagRep.status.value in { 'final', 'appended', 'corrected' }
 		return DiagRep.effective)
 	union
 	([Observation: "HPV Tests Value Set"] Obs
@@ -154,7 +154,7 @@ define "Is In Administrative Exclusions":
 	exists(
 		[Procedure: "Cervical Cytology Value Set"] Proc
 			where Proc.status.value = 'completed'
-				and Proc.performed.value before end of "Measurement Period"
+				and (Proc.performed as dateTime).value before end of "Measurement Period"
 	)
 
 /*

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -113,51 +113,62 @@ define "Is Age 30 to 64 at End":
 define "Is Cervical Cytology Test In Last 3 Years":
 	exists(
 		"Dates of Cervical Cytology Tests" WhenCC
-			where (WhenCC as dateTime).value during "Lookback Interval Two More Years"
+			where IncludedIn(WhenCC, "Lookback Interval Two More Years")
 	)
 
 define "Is Cervical Cytology Plus HPV Test In Last 5 Years":
 	exists(
 		"Dates of Cervical Cytology Tests" WhenCC
 			with "Dates of HPV Tests" WhenHPV
-				such that ((difference in days between (WhenCC as dateTime).value and (WhenHPV as dateTime).value) <= 4)
-			where (WhenCC as dateTime).value during "Lookback Interval Four More Years"
+				such that ((difference in days between start of WhenCC and start of WhenHPV) <= 4)
+			where IncludedIn(WhenCC, "Lookback Interval Four More Years")
 	)
 
 define "Dates of Cervical Cytology Tests":
 	([Procedure: "Cervical Cytology Value Set"] Proc
 		where Proc.status.value = 'completed'
-		return Proc.performed)
+		return ChoiceToIntervalOfDT(Proc.performed))
 	union
 	([DiagnosticReport: "Cervical Cytology Value Set"] DiagRep
 		where DiagRep.status.value in { 'final', 'appended', 'corrected' }
-		return DiagRep.effective)
+		return ChoiceToIntervalOfDT(DiagRep.effective))
 	union
 	([Observation: "Cervical Cytology Value Set"] Obs
 		where Obs.status.value in { 'final', 'amended' }
-		return Obs.effective)
+		return ChoiceToIntervalOfDT(Obs.effective))
 
 define "Dates of HPV Tests":
 	([Procedure: "HPV Tests Value Set"] Proc
 		where Proc.status.value = 'completed'
-		return Proc.performed)
+		return ChoiceToIntervalOfDT(Proc.performed))
 	union
 	([DiagnosticReport: "HPV Tests Value Set"] DiagRep
 		where DiagRep.status.value in { 'final', 'appended', 'corrected' }
-		return DiagRep.effective)
+		return ChoiceToIntervalOfDT(DiagRep.effective))
 	union
 	([Observation: "HPV Tests Value Set"] Obs
 		where Obs.status.value in { 'final', 'amended' }
-		return Obs.effective)
+		return ChoiceToIntervalOfDT(Obs.effective))
 
 define "Is In Administrative Exclusions":
 	exists(
 		[Procedure: "Cervical Cytology Value Set"] Proc
 			where Proc.status.value = 'completed'
-				and (Proc.performed as dateTime).value before end of "Measurement Period"
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
 	)
 
 /*
 Hybrid Specification
 TODO, if needed
 */
+
+
+/*
+Utility Functions
+*/
+
+define function ChoiceToIntervalOfDT(value Choice<FHIR.dateTime, FHIR.Period>):
+	if value is FHIR.dateTime then
+		Interval[value.value, value.value]
+	else
+		Interval[value."start".value, value."end".value]

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -5,11 +5,7 @@ Cervical Cancer Screening (CCS)
 library CCS_FHIR version '1.0.0'
 
 //using FHIR version '3.0.1'
-//using FHIR version '3.0.0'
-using FHIR version '1.8'
-
-//include FHIRHelpers version '3.0.1' called FHIRHelpers
-include FHIRHelpers version '1.8' called FHIRHelpers
+using FHIR version '3.0.0'
 
 /*
 Description
@@ -66,7 +62,7 @@ define "Is In Eligible Population":
 		and "Is Not In Hospice"
 
 define "Is Female":
-	Patient.gender = 'female'
+	Patient.gender.value = 'female'
 
 define "Is Age 24 to 64":
 	AgeInYearsAt(end of "Measurement Period") between 24 and 64
@@ -75,13 +71,16 @@ define "Is Age 24 to 64":
 // measurement year; the following test is a placeholder for that.
 // An alternate formulation using ToContext() yielded compilation errors.
 define "Is Not In Hospice":
+	true
+/*
 	not exists(
 		[DocumentReference] DocRef
-			where (DocRef.status = 'current')
+			where (DocRef.status.value = 'current')
 				and (DocRef."context".period overlaps "Measurement Period")
 				and ((DocRef."context".facilityType.coding elem return elem.code)
 					contains "Facility Type Code Value Set: Hospice facility")
 	)
+*/
 
 define "Is In Eligible Population Commercial":
 	"Is In Eligible Population"
@@ -133,48 +132,48 @@ define "Is Age 30 to 64":
 define "Is Cervical Cytology Test In Last 3 Years":
 	exists(
 		"Dates of Cervical Cytology Tests" WhenCC
-			where WhenCC during "Lookback Interval Three Years"
+			where WhenCC.value during "Lookback Interval Three Years"
 	)
 
 define "Is Cervical Cytology Plus HPV Test In Last 5 Years":
 	exists(
 		"Dates of Cervical Cytology Tests" WhenCC
 			with "Dates of HPV Tests" WhenHPV
-				such that ((difference in days between WhenCC and WhenHPV) <= 4)
-			where WhenCC during "Lookback Interval Five Years"
+				such that ((difference in days between WhenCC.value and WhenHPV.value) <= 4)
+			where WhenCC.value during "Lookback Interval Five Years"
 	)
 
 define "Dates of Cervical Cytology Tests":
 	([Procedure: "Cervical Cytology Value Set"] Proc
-		where Proc.status = 'completed'
+		where Proc.status.value = 'completed'
 		return Proc.performed)
 	union
 	([DiagnosticReport: "Cervical Cytology Value Set"] DiagRep
-		where DiagRep.status = 'final'
+		where DiagRep.status.value = 'final'
 		return DiagRep.effective)
 	union
 	([Observation: "Cervical Cytology Value Set"] Obs
-		where Obs.status in { 'final', 'amended' }
+		where Obs.status.value in { 'final', 'amended' }
 		return Obs.effective)
 
 define "Dates of HPV Tests":
 	([Procedure: "HPV Tests Value Set"] Proc
-		where Proc.status = 'completed'
+		where Proc.status.value = 'completed'
 		return Proc.performed)
 	union
 	([DiagnosticReport: "HPV Tests Value Set"] DiagRep
-		where DiagRep.status = 'final'
+		where DiagRep.status.value = 'final'
 		return DiagRep.effective)
 	union
 	([Observation: "HPV Tests Value Set"] Obs
-		where Obs.status in { 'final', 'amended' }
+		where Obs.status.value in { 'final', 'amended' }
 		return Obs.effective)
 
 define "Is In Denominator Exclusions":
 	exists(
 		[Procedure: "Cervical Cytology Value Set"] Proc
-			where Proc.status = 'completed'
-				and Proc.performed before end of "Measurement Period"
+			where Proc.status.value = 'completed'
+				and Proc.performed.value before end of "Measurement Period"
 	)
 
 /*

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -1,0 +1,183 @@
+/*
+Cervical Cancer Screening (CCS)
+*/
+
+library CCS_FHIR version '1.0.0'
+
+//using FHIR version '3.0.1'
+//using FHIR version '3.0.0'
+using FHIR version '1.8'
+
+//include FHIRHelpers version '3.0.1' called FHIRHelpers
+include FHIRHelpers version '1.8' called FHIRHelpers
+
+/*
+Description
+The percentage of women 21–64 years of age who were screened for cervical
+		cancer using either of the following criteria:
+•	Women 21–64 years of age who had cervical cytology performed every 3 years.
+•	Women 30–64 years of age who had cervical cytology/human papillomavirus
+		(HPV) co-testing performed every 5 years.
+*/
+
+codesystem "SNOMED": 'http://snomed.info/sct'
+
+valueset "Facility Type Code Value Set": 'urn:oid:2.16.840.1.113883.3.88.12.80.67'
+	// Defining URL: 'http://hl7.org/fhir/ValueSet/c80-facilitycodes'
+
+valueset "Cervical Cytology Value Set": 'TODO'
+valueset "HPV Tests Value Set": 'TODO'
+valueset "Absence of Cervix Value Set": 'TODO'
+
+/*
+This library has a single explicit parameter which is the measurement year.
+While the actual parameter's type accepts all intervals, this library
+expects it will only be given arguments corresponding exactly to one whole
+calendar year, and it will not behave properly otherwise; 2015 for example:
+Interval[DateTime(2015,1,1,0,0,0,0), DateTime(2016,1,1,0,0,0,0))
+*/
+
+parameter "Measurement Period" Interval<DateTime>
+
+define "Lookback Interval Three Years":
+	Interval[start of "Measurement Period" - 3 years, end of "Measurement Period")
+
+define "Lookback Interval Five Years":
+	Interval[start of "Measurement Period" - 5 years, end of "Measurement Period")
+
+/*
+This library evaluates with respect to exactly 1 candidate patient at a time,
+that patient being given by the special context parameter Patient.
+*/
+
+context Patient
+
+//define "Facility Type Code Value Set: Hospice facility": Concept { Code '284546000' from "SNOMED" }
+define "Facility Type Code Value Set: Hospice facility": '284546000'
+
+/*
+Eligible Population
+Product lines -- Commercial, Medicaid (report each product line separately).
+*/
+
+define "Is In Eligible Population":
+	"Is Female"
+		and "Is Age 24 to 64"
+		and "Is Not In Hospice"
+
+define "Is Female":
+	Patient.gender = 'female'
+
+define "Is Age 24 to 64":
+	AgeInYearsAt(end of "Measurement Period") between 24 and 64
+
+// TODO: Determine properly whether the patient was in hospice during the
+// measurement year; the following test is a placeholder for that.
+// An alternate formulation using ToContext() yielded compilation errors.
+define "Is Not In Hospice":
+	not exists(
+		[DocumentReference] DocRef
+			where (DocRef.status = 'current')
+				and (DocRef."context".period overlaps "Measurement Period")
+				and ((DocRef."context".facilityType.coding elem return elem.code)
+					contains "Facility Type Code Value Set: Hospice facility")
+	)
+
+define "Is In Eligible Population Commercial":
+	"Is In Eligible Population"
+		and "Is Continuous Enrollment Commercial"
+
+define "Is Continuous Enrollment Commercial":
+	true
+	// TODO: Determine continuous enrollment over the 3 year period consisting
+	// of the measurement year plus the 2 prior years.
+	// Allowable gap -- No more than one gap in enrollment of up to 45 days during
+	// each year of continuous enrollment.
+	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
+	// marked as a stub / draft / incomplete.
+
+define "Is In Eligible Population Medicaid":
+	"Is In Eligible Population"
+		and "Is Continuous Enrollment Medicaid"
+
+define "Is Continuous Enrollment Medicaid":
+	true
+	// TODO: Determine continuous enrollment over the measurement year.
+	// Allowable gap -- No more than one gap in enrollment of up to 45 days during
+	// each year of continuous enrollment. To determine continuous enrollment
+	// for a Medicaid beneficiary for whom enrollment is verified monthly, the
+	// member may not have more than a 1-month gap in coverage (i.e., a member
+	// whose coverage lapses for 2 months [60 days] is not considered continuously enrolled).
+	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
+	// marked as a stub / draft / incomplete.
+
+/*
+Administrative Specification
+*/
+
+define "Is In Denominator":
+	"Is In Eligible Population"
+
+define "Is In Numerator":
+	case
+		when (not "Is In Eligible Population") then false
+		when "Is Cervical Cytology Test In Last 3 Years" then true
+		when (not "Is Age 30 to 64") then false
+		when "Is Cervical Cytology Plus HPV Test In Last 5 Years" then true
+		else false
+	end
+
+define "Is Age 30 to 64":
+	AgeInYearsAt(end of "Measurement Period") between 30 and 64
+
+define "Is Cervical Cytology Test In Last 3 Years":
+	exists(
+		"Dates of Cervical Cytology Tests" WhenCC
+			where WhenCC during "Lookback Interval Three Years"
+	)
+
+define "Is Cervical Cytology Plus HPV Test In Last 5 Years":
+	exists(
+		"Dates of Cervical Cytology Tests" WhenCC
+			with "Dates of HPV Tests" WhenHPV
+				such that ((difference in days between WhenCC and WhenHPV) <= 4)
+			where WhenCC during "Lookback Interval Five Years"
+	)
+
+define "Dates of Cervical Cytology Tests":
+	([Procedure: "Cervical Cytology Value Set"] Proc
+		where Proc.status = 'completed'
+		return Proc.performed)
+	union
+	([DiagnosticReport: "Cervical Cytology Value Set"] DiagRep
+		where DiagRep.status = 'final'
+		return DiagRep.effective)
+	union
+	([Observation: "Cervical Cytology Value Set"] Obs
+		where Obs.status in { 'final', 'amended' }
+		return Obs.effective)
+
+define "Dates of HPV Tests":
+	([Procedure: "HPV Tests Value Set"] Proc
+		where Proc.status = 'completed'
+		return Proc.performed)
+	union
+	([DiagnosticReport: "HPV Tests Value Set"] DiagRep
+		where DiagRep.status = 'final'
+		return DiagRep.effective)
+	union
+	([Observation: "HPV Tests Value Set"] Obs
+		where Obs.status in { 'final', 'amended' }
+		return Obs.effective)
+
+define "Is In Denominator Exclusions":
+	exists(
+		[Procedure: "Cervical Cytology Value Set"] Proc
+			where Proc.status = 'completed'
+				and Proc.performed before end of "Measurement Period"
+	)
+
+/*
+Hybrid Specification
+TODO, if needed
+*/

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -16,11 +16,6 @@ The percentage of women 21–64 years of age who were screened for cervical
 		(HPV) co-testing performed every 5 years.
 */
 
-codesystem "SNOMED": 'http://snomed.info/sct'
-
-valueset "Facility Type Code Value Set": 'urn:oid:2.16.840.1.113883.3.88.12.80.67'
-	// Defining URL: 'http://hl7.org/fhir/ValueSet/c80-facilitycodes'
-
 valueset "Cervical Cytology Value Set": 'TODO'
 valueset "HPV Tests Value Set": 'TODO'
 valueset "Absence of Cervix Value Set": 'TODO'
@@ -35,11 +30,11 @@ Interval[DateTime(2015,1,1,0,0,0,0), DateTime(2016,1,1,0,0,0,0))
 
 parameter "Measurement Period" Interval<DateTime>
 
-define "Lookback Interval Three Years":
-	Interval[start of "Measurement Period" - 3 years, end of "Measurement Period")
+define "Lookback Interval Two More Years":
+	Interval[start of "Measurement Period" - 2 years, end of "Measurement Period")
 
-define "Lookback Interval Five Years":
-	Interval[start of "Measurement Period" - 5 years, end of "Measurement Period")
+define "Lookback Interval Four More Years":
+	Interval[start of "Measurement Period" - 4 years, end of "Measurement Period")
 
 /*
 This library evaluates with respect to exactly 1 candidate patient at a time,
@@ -47,9 +42,6 @@ that patient being given by the special context parameter Patient.
 */
 
 context Patient
-
-//define "Facility Type Code Value Set: Hospice facility": Concept { Code '284546000' from "SNOMED" }
-define "Facility Type Code Value Set: Hospice facility": '284546000'
 
 /*
 Eligible Population
@@ -67,20 +59,9 @@ define "Is Female":
 define "Is Age 24 to 64":
 	AgeInYearsAt(end of "Measurement Period") between 24 and 64
 
-// TODO: Determine properly whether the patient was in hospice during the
-// measurement year; the following test is a placeholder for that.
-// An alternate formulation using ToContext() yielded compilation errors.
 define "Is Not In Hospice":
 	true
-/*
-	not exists(
-		[DocumentReference] DocRef
-			where (DocRef.status.value = 'current')
-				and (DocRef."context".period overlaps "Measurement Period")
-				and ((DocRef."context".facilityType.coding elem return elem.code)
-					contains "Facility Type Code Value Set: Hospice facility")
-	)
-*/
+	// TODO: Determine properly whether the patient was in hospice during the measurement year.
 
 define "Is In Eligible Population Commercial":
 	"Is In Eligible Population"
@@ -132,7 +113,7 @@ define "Is Age 30 to 64":
 define "Is Cervical Cytology Test In Last 3 Years":
 	exists(
 		"Dates of Cervical Cytology Tests" WhenCC
-			where WhenCC.value during "Lookback Interval Three Years"
+			where WhenCC.value during "Lookback Interval Two More Years"
 	)
 
 define "Is Cervical Cytology Plus HPV Test In Last 5 Years":
@@ -140,7 +121,7 @@ define "Is Cervical Cytology Plus HPV Test In Last 5 Years":
 		"Dates of Cervical Cytology Tests" WhenCC
 			with "Dates of HPV Tests" WhenHPV
 				such that ((difference in days between WhenCC.value and WhenHPV.value) <= 4)
-			where WhenCC.value during "Lookback Interval Five Years"
+			where WhenCC.value during "Lookback Interval Four More Years"
 	)
 
 define "Dates of Cervical Cytology Tests":

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -50,17 +50,17 @@ Product lines -- Commercial, Medicaid (report each product line separately).
 
 define "Is In Eligible Population":
 	"Is Female"
-		and "Is Age 24 to 64"
-		and "Is Not In Hospice"
+		and "Is Age 24 to 64 at End"
+		and (not "Is In Hospice")
 
 define "Is Female":
 	Patient.gender.value = 'female'
 
-define "Is Age 24 to 64":
+define "Is Age 24 to 64 at End":
 	AgeInYearsAt(end of "Measurement Period") between 24 and 64
 
-define "Is Not In Hospice":
-	true
+define "Is In Hospice":
+	false
 	// TODO: Determine properly whether the patient was in hospice during the measurement year.
 
 define "Is In Eligible Population Commercial":
@@ -102,26 +102,26 @@ define "Is In Numerator":
 	case
 		when (not "Is In Eligible Population") then false
 		when "Is Cervical Cytology Test In Last 3 Years" then true
-		when (not "Is Age 30 to 64") then false
+		when (not "Is Age 30 to 64 at End") then false
 		when "Is Cervical Cytology Plus HPV Test In Last 5 Years" then true
 		else false
 	end
 
-define "Is Age 30 to 64":
+define "Is Age 30 to 64 at End":
 	AgeInYearsAt(end of "Measurement Period") between 30 and 64
 
 define "Is Cervical Cytology Test In Last 3 Years":
 	exists(
 		"Dates of Cervical Cytology Tests" WhenCC
-			where WhenCC.value during "Lookback Interval Two More Years"
+			where (WhenCC as dateTime).value during "Lookback Interval Two More Years"
 	)
 
 define "Is Cervical Cytology Plus HPV Test In Last 5 Years":
 	exists(
 		"Dates of Cervical Cytology Tests" WhenCC
 			with "Dates of HPV Tests" WhenHPV
-				such that ((difference in days between WhenCC.value and WhenHPV.value) <= 4)
-			where WhenCC.value during "Lookback Interval Four More Years"
+				such that ((difference in days between (WhenCC as dateTime).value and (WhenHPV as dateTime).value) <= 4)
+			where (WhenCC as dateTime).value during "Lookback Interval Four More Years"
 	)
 
 define "Dates of Cervical Cytology Tests":
@@ -150,7 +150,7 @@ define "Dates of HPV Tests":
 		where Obs.status.value in { 'final', 'amended' }
 		return Obs.effective)
 
-define "Is In Denominator Exclusions":
+define "Is In Administrative Exclusions":
 	exists(
 		[Procedure: "Cervical Cytology Value Set"] Proc
 			where Proc.status.value = 'completed'

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -120,7 +120,9 @@ define "Is Cervical Cytology Plus HPV Test In Last 5 Years":
 	exists(
 		"Dates of Cervical Cytology Tests" WhenCC
 			with "Dates of HPV Tests" WhenHPV
-				such that ((difference in days between start of WhenCC and start of WhenHPV) <= 4)
+				such that (((difference in days between start of WhenCC and start of WhenHPV) <= 4)
+					and AgeInYearsAt(start of WhenCC) >= 30
+					and AgeInYearsAt(start of WhenHPV) >= 30)
 			where IncludedIn(WhenCC, "Lookback Interval Four More Years")
 	)
 

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -1,0 +1,181 @@
+/*
+Colorectal Cancer Screening (COL)
+*/
+
+library COL_FHIR version '1.0.0'
+
+//using FHIR version '3.0.1'
+using FHIR version '3.0.0'
+
+/*
+Description
+The percentage of members 50–75 years of age who had appropriate screening for colorectal cancer.
+*/
+
+valueset "FOBT Value Set": 'TODO'
+valueset "Flexible Sigmoidoscopy Value Set": 'TODO'
+valueset "Colonoscopy Value Set": 'TODO'
+valueset "CT Colonography Value Set": 'TODO'
+valueset "FIT-DNA Value Set": 'TODO'
+
+valueset "Colorectal Cancer Value Set": 'TODO'
+valueset "Total Colectomy Value Set": 'TODO'
+
+/*
+This library has a single explicit parameter which is the measurement year.
+While the actual parameter's type accepts all intervals, this library
+expects it will only be given arguments corresponding exactly to one whole
+calendar year, and it will not behave properly otherwise; 2015 for example:
+Interval[DateTime(2015,1,1,0,0,0,0), DateTime(2016,1,1,0,0,0,0))
+*/
+
+parameter "Measurement Period" Interval<DateTime>
+
+define "Lookback Interval Two More Years":
+	Interval[start of "Measurement Period" - 2 years, end of "Measurement Period")
+
+define "Lookback Interval Four More Years":
+	Interval[start of "Measurement Period" - 4 years, end of "Measurement Period")
+
+define "Lookback Interval Nine More Years":
+	Interval[start of "Measurement Period" - 9 years, end of "Measurement Period")
+
+/*
+This library evaluates with respect to exactly 1 candidate patient at a time,
+that patient being given by the special context parameter Patient.
+*/
+
+context Patient
+
+/*
+Eligible Population
+Product lines -- Commercial, Medicare (report each product line separately).
+*/
+
+define "Is In Eligible Population":
+	"Is Age 51 to 75 at End"
+		and (not "Is In Hospice")
+
+define "Is Age 51 to 75 at End":
+	AgeInYearsAt(end of "Measurement Period") between 51 and 75
+
+define "Is In Hospice":
+	false
+	// TODO: Determine properly whether the patient was in hospice during the measurement year.
+
+define "Is In Eligible Population Commercial":
+	"Is In Eligible Population"
+		and "Is Continuous Enrollment Commercial"
+
+define "Is Continuous Enrollment Commercial":
+	true
+	// TODO: Determine continuous enrollment over the 2 year period consisting
+	// of the measurement year plus the 1 prior year.
+	// Allowable gap -- No more than one gap in enrollment of up to 45 days during
+	// each year of continuous enrollment.
+	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
+	// marked as a stub / draft / incomplete.
+
+define "Is In Eligible Population Medicare":
+	"Is In Eligible Population"
+		and "Is Continuous Enrollment Medicare"
+		and (if "Is Age 65 Plus at Start"
+			then ("Is Enrolled in Institutional SNP"
+				or "Is Living Long-Term in Institution")
+			else false)
+
+define "Is Continuous Enrollment Medicare":
+	true
+	// TODO: Determine continuous enrollment over the 2 year period consisting
+	// of the measurement year plus the 1 prior year.
+	// Allowable gap -- No more than one gap in enrollment of up to 45 days during
+	// each year of continuous enrollment.
+	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
+	// marked as a stub / draft / incomplete.
+
+define "Is Age 65 Plus at Start":
+	AgeInYearsAt(start of "Measurement Period") >= 65
+
+define "Is Enrolled in Institutional SNP":
+	false
+	// TODO: Determine properly whether the patient was in SNP during the measurement year.
+
+define "Is Living Long-Term in Institution":
+	false
+	// TODO: Determine properly whether the patient was in LTI during the measurement year.
+
+/*
+Administrative Specification
+*/
+
+define "Is In Denominator":
+	"Is In Eligible Population"
+
+define "Is In Numerator":
+	"Is In Eligible Population"
+		and "Is Colorectal Cancer Screening"
+
+define "Is Colorectal Cancer Screening":
+	"Is Fecal Occult Blood Test In Last Year"
+		or "Is Flexible Sigmoidoscopy In Last Five Years"
+		or "Is Colonoscopy In Last Ten Years"
+		or "Is CT Colonography In Last Five Years"
+		or "Is FIT-DNA Test In Last Three Years"
+
+define "Is Fecal Occult Blood Test In Last Year":
+	exists(
+		[Observation: "FOBT Value Set"] Obs
+			where Obs.status.value in { 'final', 'amended' }
+				and (Obs.effective as dateTime).value during "Measurement Period"
+	)
+
+define "Is Flexible Sigmoidoscopy In Last Five Years":
+	exists(
+		[DiagnosticReport: "Flexible Sigmoidoscopy Value Set"] DiagRep
+			where DiagRep.status.value in { 'final', 'appended', 'corrected' }
+				and (DiagRep.effective as dateTime).value during "Lookback Interval Four More Years"
+	)
+
+define "Is Colonoscopy In Last Ten Years":
+	exists(
+		[DiagnosticReport: "Colonoscopy Value Set"] DiagRep
+			where DiagRep.status.value in { 'final', 'appended', 'corrected' }
+				and (DiagRep.effective as dateTime).value during "Lookback Interval Nine More Years"
+	)
+
+define "Is CT Colonography In Last Five Years":
+	exists(
+		[DiagnosticReport: "CT Colonography Value Set"] DiagRep
+			where DiagRep.status.value in { 'final', 'appended', 'corrected' }
+				and (DiagRep.effective as dateTime).value during "Lookback Interval Four More Years"
+	)
+
+define "Is FIT-DNA Test In Last Three Years":
+	exists(
+		[Observation: "FIT-DNA Value Set"] Obs
+			where Obs.status.value in { 'final', 'amended' }
+				and (Obs.effective as dateTime).value during "Lookback Interval Two More Years"
+	)
+
+define "Is In Administrative Exclusions":
+	"Is Colorectal Cancer"
+		or "Is Total Colectomy"
+
+define "Is Colorectal Cancer":
+	exists(
+		[Condition: "Colorectal Cancer Value Set"] Cond
+			where Cond.verificationStatus.value = 'confirmed'
+				and (Cond.assertedDate as dateTime).value before end of "Measurement Period"
+	)
+
+define "Is Total Colectomy":
+	exists(
+		[Procedure: "Total Colectomy Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and (Proc.performed as dateTime).value before end of "Measurement Period"
+	)
+
+/*
+Hybrid Specification
+TODO, if needed
+*/

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -126,35 +126,35 @@ define "Is Fecal Occult Blood Test In Last Year":
 	exists(
 		[Observation: "FOBT Value Set"] Obs
 			where Obs.status.value in { 'final', 'amended' }
-				and (Obs.effective as dateTime).value during "Measurement Period"
+				and IncludedIn(ChoiceToIntervalOfDT(Obs.effective), "Measurement Period")
 	)
 
 define "Is Flexible Sigmoidoscopy In Last Five Years":
 	exists(
 		[DiagnosticReport: "Flexible Sigmoidoscopy Value Set"] DiagRep
 			where DiagRep.status.value in { 'final', 'appended', 'corrected' }
-				and (DiagRep.effective as dateTime).value during "Lookback Interval Four More Years"
+				and IncludedIn(ChoiceToIntervalOfDT(DiagRep.effective), "Lookback Interval Four More Years")
 	)
 
 define "Is Colonoscopy In Last Ten Years":
 	exists(
 		[DiagnosticReport: "Colonoscopy Value Set"] DiagRep
 			where DiagRep.status.value in { 'final', 'appended', 'corrected' }
-				and (DiagRep.effective as dateTime).value during "Lookback Interval Nine More Years"
+				and IncludedIn(ChoiceToIntervalOfDT(DiagRep.effective), "Lookback Interval Nine More Years")
 	)
 
 define "Is CT Colonography In Last Five Years":
 	exists(
 		[DiagnosticReport: "CT Colonography Value Set"] DiagRep
 			where DiagRep.status.value in { 'final', 'appended', 'corrected' }
-				and (DiagRep.effective as dateTime).value during "Lookback Interval Four More Years"
+				and IncludedIn(ChoiceToIntervalOfDT(DiagRep.effective), "Lookback Interval Four More Years")
 	)
 
 define "Is FIT-DNA Test In Last Three Years":
 	exists(
 		[Observation: "FIT-DNA Value Set"] Obs
 			where Obs.status.value in { 'final', 'amended' }
-				and (Obs.effective as dateTime).value during "Lookback Interval Two More Years"
+				and IncludedIn(ChoiceToIntervalOfDT(Obs.effective), "Lookback Interval Two More Years")
 	)
 
 define "Is In Administrative Exclusions":
@@ -165,17 +165,28 @@ define "Is Colorectal Cancer":
 	exists(
 		[Condition: "Colorectal Cancer Value Set"] Cond
 			where Cond.verificationStatus.value = 'confirmed'
-				and (Cond.assertedDate as dateTime).value before end of "Measurement Period"
+				and Cond.assertedDate.value before end of "Measurement Period"
 	)
 
 define "Is Total Colectomy":
 	exists(
 		[Procedure: "Total Colectomy Value Set"] Proc
 			where Proc.status.value = 'completed'
-				and (Proc.performed as dateTime).value before end of "Measurement Period"
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
 	)
 
 /*
 Hybrid Specification
 TODO, if needed
 */
+
+
+/*
+Utility Functions
+*/
+
+define function ChoiceToIntervalOfDT(value Choice<FHIR.dateTime, FHIR.Period>):
+	if value is FHIR.dateTime then
+		Interval[value.value, value.value]
+	else
+		Interval[value."start".value, value."end".value]


### PR DESCRIPTION
This pull request includes 3 new CQL measures named with -2018 which rewrite the corresponding 3 measures for CCS+BCS+COL lacking the -2018 in their names.

That rewrite is a work in progress and this pull request has the work done so far, in order that review and feedback may be made on it.

This pull request should not actually be merged yet and the work will receive more iterations before it is truly "done".