### PR TITLE
in 2018 measures, add BCS mastectomy exclusion, add hospice check, add continuous enrolment check

### DIFF
--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -98,7 +98,7 @@ define "Is In Hospice":
 	exists(
 		[Encounter: "Hospice Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
 	)
 
 define "Is In Applicable Product Line":
@@ -186,7 +186,7 @@ define "Is Enrolled in Institutional SNP":
 	exists(
 		[Encounter: "X Institutional SNP Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
 	)
 	// TODO: Determine properly whether the patient was in SNP during the measurement year.
 
@@ -194,7 +194,7 @@ define "Is Living Long-Term in Institution":
 	exists(
 		[Encounter: "X Long-Term in Institution Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
 	)
 	// TODO: Determine properly whether the patient was in LTI during the measurement year.
 

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -27,6 +27,10 @@ valueset "Unilateral Mastectomy Right Value Set": 'TODO'
 
 valueset "Hospice Value Set": 'TODO'
 
+valueset "X Commercial Coverage Value Set": 'TODO'
+valueset "X Medicaid Coverage Value Set": 'TODO'
+valueset "X Medicare Coverage Value Set": 'TODO'
+
 valueset "X Institutional SNP Value Set": 'TODO'
 valueset "X Long-Term in Institution Value Set": 'TODO'
 
@@ -111,38 +115,25 @@ define "Is In Applicable Product Line":
 		else false
 	end
 
-define "Any Patient Coverage At Any Time":
-	[Coverage] Cov
-		where Cov.status.value in { 'active', 'cancelled' }
+define "Enrollment Periods":
+	collapse(
+		[Coverage] Cov
+			where Cov.status.value in { 'active', 'cancelled' }
+				and case "Product Line"
+					when 'commercial' then
+						CodingToCode(Cov.type.coding) in "X Commercial Coverage Value Set"
+					when 'medicaid' then
+						CodingToCode(Cov.type.coding) in "X Medicaid Coverage Value Set"
+					when 'medicare' then
+						CodingToCode(Cov.type.coding) in "X Medicare Coverage Value Set"
+					else false
+				end
+			return PeriodToIntervalOfDT(Cov.period)
+	)
 	// We assume [Coverage] in Patient context implicitly has this filter:
 	// Cov.beneficiary.identifier = Patient.identifier
 	// ... and that the paitient is not connected as a policy holder or payor.
-
-define "Product Line Organizations":
-	case "Product Line"
-		when 'commercial' then
-			[Organization] Org
-				where Org.name.value not in { 'Medicaid', 'Medicare' }
-		when 'medicaid' then
-			[Organization] Org
-				where Org.name.value in { 'Medicaid' }
-		when 'medicare' then
-			[Organization] Org
-				where Org.name.value in { 'Medicare' }
-		else List<FHIR.Organization> {}
-	end
 	// TODO: Properly determine organization(s) for the product line.
-
-define "Enrollment Periods":
-	collapse(
-		"Any Patient Coverage At Any Time" Cov
-			with "Product Line Organizations" Org
-				such that
-					(if Cov.payor is List<FHIR.Reference>
-						then (Cov.payor as List<FHIR.Reference>).identifier = Org.identifier
-						else false)
-			return PeriodToIntervalOfDT(Cov.period)
-	)
 	// Note: collapse() also puts the resulting intervals in order.
 
 define function "Enrollment Periods In Year"(Year Interval<DateTime>):
@@ -400,3 +391,12 @@ define function ChoiceToIntervalOfDT(value Choice<FHIR.dateTime, FHIR.Period>):
 
 define function PeriodToIntervalOfDT(value FHIR.Period):
 	Interval[value."start".value, value."end".value]
+
+define function CodingToCode(coding FHIR.Coding):
+	System.Code {
+		code: coding.code.value,
+		system: coding.system.value,
+		version: coding.version.value,
+		display: coding.display.value
+	}
+	// From FHIRHelpers

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -27,6 +27,9 @@ valueset "Unilateral Mastectomy Right Value Set": 'TODO'
 
 valueset "Hospice Value Set": 'TODO'
 
+valueset "X Institutional SNP Value Set": 'TODO'
+valueset "X Long-Term in Institution Value Set": 'TODO'
+
 /*
 This library has an explicit parameter which is the product line.
 Recognized normal arguments are {'commercial', 'medicaid', 'medicare'}.
@@ -189,11 +192,19 @@ define "Is Age 65 Plus at Start":
 	AgeInYearsAt(start of "Measurement Period") >= 65
 
 define "Is Enrolled in Institutional SNP":
-	false
+	exists(
+		[Encounter: "X Institutional SNP Value Set"] Enc
+			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+	)
 	// TODO: Determine properly whether the patient was in SNP during the measurement year.
 
 define "Is Living Long-Term in Institution":
-	false
+	exists(
+		[Encounter: "X Long-Term in Institution Value Set"] Enc
+			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+	)
 	// TODO: Determine properly whether the patient was in LTI during the measurement year.
 
 /*

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -28,7 +28,21 @@ valueset "Unilateral Mastectomy Right Value Set": 'TODO'
 valueset "Hospice Value Set": 'TODO'
 
 /*
-This library has a single explicit parameter which is the measurement year.
+This library has an explicit parameter which is the product line.
+Recognized normal arguments are {'commercial', 'medicaid', 'medicare'}.
+If one of these normal arguments is given, the patient will only be
+considered to be in the Eligible Population if they have an appropriate
+continuous enrollment in that kind of medical plan.
+If instead a null argument is given, their enrollment status will have no
+effect on whether they are considered to be in the Eligible Population.
+If instead some other argument is given (an unrecognized plan type),
+the patient will unconditionally NOT be in the Eligible Population.
+*/
+
+parameter "Product Line" String
+
+/*
+This library has an explicit parameter which is the measurement year.
 While the actual parameter's type accepts all intervals, this library
 expects it will only be given arguments corresponding exactly to one whole
 calendar year, and it will not behave properly otherwise; 2015 for example:
@@ -56,6 +70,7 @@ define "Is In Eligible Population":
 	"Is Female"
 		and "Is Age 52 to 74 at End"
 		and (not "Is In Hospice")
+		and "Is In Applicable Product Line"
 
 define "Is Female":
 	Patient.gender.value = 'female'
@@ -70,9 +85,19 @@ define "Is In Hospice":
 				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
 	)
 
-define "Is In Eligible Population Commercial":
-	"Is In Eligible Population"
-		and "Is Continuous Enrollment Commercial"
+define "Is In Applicable Product Line":
+	case
+		when ("Product Line" ~ null) then true
+		when ("Product Line" = 'commercial') then "Is Continuous Enrollment Commercial"
+		when ("Product Line" = 'medicaid') then "Is Continuous Enrollment Medicaid"
+		when ("Product Line" = 'medicare') then
+			("Is Continuous Enrollment Medicare"
+				and (if "Is Age 65 Plus at Start"
+					then ("Is Enrolled in Institutional SNP"
+						or "Is Living Long-Term in Institution")
+					else false))
+		else false
+	end
 
 define "Is Continuous Enrollment Commercial":
 	true
@@ -84,10 +109,6 @@ define "Is Continuous Enrollment Commercial":
 	// measurement year and the year prior to the measurement year).
 	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
 	// marked as a stub / draft / incomplete.
-
-define "Is In Eligible Population Medicaid":
-	"Is In Eligible Population"
-		and "Is Continuous Enrollment Medicaid"
 
 define "Is Continuous Enrollment Medicaid":
 	true
@@ -104,14 +125,6 @@ define "Is Continuous Enrollment Medicaid":
 	// to the measurement year).
 	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
 	// marked as a stub / draft / incomplete.
-
-define "Is In Eligible Population Medicare":
-	"Is In Eligible Population"
-		and "Is Continuous Enrollment Medicare"
-		and (if "Is Age 65 Plus at Start"
-			then ("Is Enrolled in Institutional SNP"
-				or "Is Living Long-Term in Institution")
-			else false)
 
 define "Is Continuous Enrollment Medicare":
 	true

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -27,6 +27,11 @@ valueset "Unilateral Mastectomy Right Value Set": 'TODO'
 
 valueset "Hospice Value Set": 'TODO'
 
+valueset "Encounter Inpatient": 'urn:oid:2.16.840.1.113883.3.666.5.307' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+valueset "Discharged to Home for Hospice Care": 'urn:oid:2.16.840.1.113883.3.117.1.7.1.209' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+valueset "Discharged to Health Care Facility for Hospice Care": 'urn:oid:2.16.840.1.113883.3.117.1.7.1.207' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+valueset "Hospice care ambulatory": 'urn:oid:2.16.840.1.113762.1.4.1108.15' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+
 valueset "X Commercial Coverage Value Set": 'TODO'
 valueset "X Medicaid Coverage Value Set": 'TODO'
 valueset "X Medicare Coverage Value Set": 'TODO'
@@ -99,6 +104,23 @@ define "Is In Hospice":
 		[Encounter: "Hospice Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
 				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
+	)
+	or
+	exists(
+		[Encounter: "Encounter Inpatient"] DischargeHospice
+			where DischargeHospice.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and (CodingToCode(DischargeHospice.hospitalization.dischargeDisposition.coding)
+						in "Discharged to Home for Hospice Care"
+					or CodingToCode(DischargeHospice.hospitalization.dischargeDisposition.coding)
+						in "Discharged to Health Care Facility for Hospice Care")
+				and PeriodToIntervalOfDT(DischargeHospice.period) ends during "Measurement Period"
+	)
+	or
+	exists(
+		[Encounter: "Hospice care ambulatory"] HospiceOrderOrPerformed
+			where HospiceOrderOrPerformed.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and (PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) during "Measurement Period"
+					or PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) overlaps "Measurement Period")
 	)
 
 define "Is In Applicable Product Line":

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -131,7 +131,7 @@ define "Enrollment Periods":
 			return PeriodToIntervalOfDT(Cov.period)
 	)
 	// We assume [Coverage] in Patient context implicitly has this filter:
-	// Cov.beneficiary.identifier = Patient.identifier
+	// Cov.beneficiary.identifier ~ Patient.identifier
 	// ... and that the paitient is not connected as a policy holder or payor.
 	// TODO: Properly determine organization(s) for the product line.
 	// Note: collapse() also puts the resulting intervals in order.
@@ -265,7 +265,7 @@ define "Is Unilateral Mastectomy With Bilateral Modifier":
 					) Proc1
 						such that
 							(if BbElem.procedure is FHIR.Reference
-								then (BbElem.procedure as FHIR.Reference).identifier = Proc1.identifier
+								then (BbElem.procedure as FHIR.Reference).identifier ~ Proc1.identifier
 								else false)
 					with (
 						[Procedure: "Bilateral Modifier Value Set"] Proc
@@ -274,7 +274,7 @@ define "Is Unilateral Mastectomy With Bilateral Modifier":
 					) Proc2
 						such that
 							(if BbElem.procedure is FHIR.Reference
-								then (BbElem.procedure as FHIR.Reference).identifier = Proc2.identifier
+								then (BbElem.procedure as FHIR.Reference).identifier ~ Proc2.identifier
 								else false)
 			)
 	)
@@ -309,7 +309,7 @@ define "Is Unilateral Mastectomy With Left Modifier":
 					) Proc1
 						such that
 							(if BbElem.procedure is FHIR.Reference
-								then (BbElem.procedure as FHIR.Reference).identifier = Proc1.identifier
+								then (BbElem.procedure as FHIR.Reference).identifier ~ Proc1.identifier
 								else false)
 					with (
 						[Procedure: "Left Modifier Value Set"] Proc
@@ -318,7 +318,7 @@ define "Is Unilateral Mastectomy With Left Modifier":
 					) Proc2
 						such that
 							(if BbElem.procedure is FHIR.Reference
-								then (BbElem.procedure as FHIR.Reference).identifier = Proc2.identifier
+								then (BbElem.procedure as FHIR.Reference).identifier ~ Proc2.identifier
 								else false)
 			)
 	)
@@ -350,7 +350,7 @@ define "Is Unilateral Mastectomy With Right Modifier":
 					) Proc1
 						such that
 							(if BbElem.procedure is FHIR.Reference
-								then (BbElem.procedure as FHIR.Reference).identifier = Proc1.identifier
+								then (BbElem.procedure as FHIR.Reference).identifier ~ Proc1.identifier
 								else false)
 					with (
 						[Procedure: "Right Modifier Value Set"] Proc
@@ -359,7 +359,7 @@ define "Is Unilateral Mastectomy With Right Modifier":
 					) Proc2
 						such that
 							(if BbElem.procedure is FHIR.Reference
-								then (BbElem.procedure as FHIR.Reference).identifier = Proc2.identifier
+								then (BbElem.procedure as FHIR.Reference).identifier ~ Proc2.identifier
 								else false)
 			)
 	)

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -151,11 +151,127 @@ define "Is Mammogram In Last 39 Months":
 	)
 
 define "Is In Administrative Exclusions":
+	"Is Lacking Both Breasts"
+		or ("Is Lacking Left Breast"
+			and "Is Lacking Right Breast")
+
+define "Is Lacking Both Breasts":
 	"Is Bilateral Mastectomy"
+		or "Is History Of Bilateral Mastectomy"
+		or "Is Unilateral Mastectomy With Bilateral Modifier"
+		or "Is Unilateral Mastectomy Twice Spread Two Weeks"
+
+define "Is Lacking Left Breast":
+	"Is Unilateral Mastectomy With Left Modifier"
+		or "Is Unilateral Mastectomy Left"
+		or "Is Absence Of Left Breast"
+
+define "Is Lacking Right Breast":
+	"Is Unilateral Mastectomy With Right Modifier"
+		or "Is Unilateral Mastectomy Right"
+		or "Is Absence Of Right Breast"
 
 define "Is Bilateral Mastectomy":
-	false
-	// TODO: Enumerate the specified alternative criteria for this.
+	exists(
+		[Procedure: "Bilateral Mastectomy Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+
+define "Is History Of Bilateral Mastectomy":
+	exists(
+		[Procedure: "History of Bilateral Mastectomy Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+	// NOTE: This assumes the history of a procedure is also recorded as a procedure in FHIR
+
+define "Is Unilateral Mastectomy With Bilateral Modifier":
+	exists(
+		[Procedure: "Unilateral Mastectomy Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+	and
+	exists(
+		[Procedure: "Bilateral Modifier Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+	// TODO: Do we need to ask that both are on the same claim?
+
+define "Is Unilateral Mastectomy Twice Spread Two Weeks":
+	exists(
+		(
+			[Procedure: "Unilateral Mastectomy Value Set"] Proc
+				where Proc.status.value = 'completed'
+				return ChoiceToIntervalOfDT(Proc.performed)
+		) WhenUM1
+			with (
+				[Procedure: "Unilateral Mastectomy Value Set"] Proc
+					where Proc.status.value = 'completed'
+					return ChoiceToIntervalOfDT(Proc.performed)
+			) WhenUM2
+				such that (((difference in days between start of WhenUM1 and start of WhenUM2) >= 14)
+					and end of WhenUM1 before end of "Measurement Period"
+					and end of WhenUM2 before end of "Measurement Period")
+	)
+
+define "Is Unilateral Mastectomy With Left Modifier":
+	exists(
+		[Procedure: "Unilateral Mastectomy Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+	and
+	exists(
+		[Procedure: "Left Modifier Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+	// TODO: How to ask that both are on the same claim?
+
+define "Is Unilateral Mastectomy Left":
+	exists(
+		[Procedure: "Unilateral Mastectomy Left Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+
+define "Is Absence Of Left Breast":
+	exists(
+		[Observation: "Absence of Left Breast Value Set"] Obs
+			where Obs.status.value in { 'final', 'amended' }
+				and end of ChoiceToIntervalOfDT(Obs.effective) before end of "Measurement Period"
+	)
+
+define "Is Unilateral Mastectomy With Right Modifier":
+	exists(
+		[Procedure: "Unilateral Mastectomy Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+	and
+	exists(
+		[Procedure: "Right Modifier Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+	// TODO: How to ask that both are on the same claim?
+
+define "Is Unilateral Mastectomy Right":
+	exists(
+		[Procedure: "Unilateral Mastectomy Right Value Set"] Proc
+			where Proc.status.value = 'completed'
+				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+	)
+
+define "Is Absence Of Right Breast":
+	exists(
+		[Observation: "Absence of Right Breast Value Set"] Obs
+			where Obs.status.value in { 'final', 'amended' }
+				and end of ChoiceToIntervalOfDT(Obs.effective) before end of "Measurement Period"
+	)
 
 
 /*

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -75,7 +75,7 @@ define "Is Continuous Enrollment Commercial":
 	true
 	// TODO: Determine continuous enrollment over the 39 month period consisting
 	// of the measurement year plus the 2 prior years plus the 3 prior months.
-	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period. 
+	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period.
 	// Allowable gap -- No more than one gap in enrollment of up to 45 days
 	// for each full calendar year of continuous enrollment (i.e., the
 	// measurement year and the year prior to the measurement year).
@@ -90,7 +90,7 @@ define "Is Continuous Enrollment Medicaid":
 	true
 	// TODO: Determine continuous enrollment over the 39 month period consisting
 	// of the measurement year plus the 2 prior years plus the 3 prior months.
-	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period. 
+	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period.
 	// Allowable gap -- No more than one gap in enrollment of up to 45 days
 	// for each full calendar year of continuous enrollment (i.e., the
 	// measurement year and the year prior to the measurement year).
@@ -114,7 +114,7 @@ define "Is Continuous Enrollment Medicare":
 	true
 	// TODO: Determine continuous enrollment over the 39 month period consisting
 	// of the measurement year plus the 2 prior years plus the 3 prior months.
-	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period. 
+	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period.
 	// Allowable gap -- No more than one gap in enrollment of up to 45 days
 	// for each full calendar year of continuous enrollment (i.e., the
 	// measurement year and the year prior to the measurement year).
@@ -188,17 +188,29 @@ define "Is History Of Bilateral Mastectomy":
 
 define "Is Unilateral Mastectomy With Bilateral Modifier":
 	exists(
-		[Procedure: "Unilateral Mastectomy Value Set"] Proc
-			where Proc.status.value = 'completed'
-				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+		[Claim] Claim
+			where exists(
+				Claim.procedure BbElem
+					with (
+						[Procedure: "Unilateral Mastectomy Value Set"] Proc
+							where Proc.status.value = 'completed'
+								and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+					) Proc1
+						such that
+							(if BbElem.procedure is FHIR.Reference
+								then (BbElem.procedure as FHIR.Reference).identifier = Proc1.identifier
+								else false)
+					with (
+						[Procedure: "Bilateral Modifier Value Set"] Proc
+							where Proc.status.value = 'completed'
+								and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+					) Proc2
+						such that
+							(if BbElem.procedure is FHIR.Reference
+								then (BbElem.procedure as FHIR.Reference).identifier = Proc2.identifier
+								else false)
+			)
 	)
-	and
-	exists(
-		[Procedure: "Bilateral Modifier Value Set"] Proc
-			where Proc.status.value = 'completed'
-				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
-	)
-	// TODO: Do we need to ask that both are on the same claim?
 
 define "Is Unilateral Mastectomy Twice Spread Two Weeks":
 	exists(
@@ -219,17 +231,29 @@ define "Is Unilateral Mastectomy Twice Spread Two Weeks":
 
 define "Is Unilateral Mastectomy With Left Modifier":
 	exists(
-		[Procedure: "Unilateral Mastectomy Value Set"] Proc
-			where Proc.status.value = 'completed'
-				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+		[Claim] Claim
+			where exists(
+				Claim.procedure BbElem
+					with (
+						[Procedure: "Unilateral Mastectomy Value Set"] Proc
+							where Proc.status.value = 'completed'
+								and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+					) Proc1
+						such that
+							(if BbElem.procedure is FHIR.Reference
+								then (BbElem.procedure as FHIR.Reference).identifier = Proc1.identifier
+								else false)
+					with (
+						[Procedure: "Left Modifier Value Set"] Proc
+							where Proc.status.value = 'completed'
+								and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+					) Proc2
+						such that
+							(if BbElem.procedure is FHIR.Reference
+								then (BbElem.procedure as FHIR.Reference).identifier = Proc2.identifier
+								else false)
+			)
 	)
-	and
-	exists(
-		[Procedure: "Left Modifier Value Set"] Proc
-			where Proc.status.value = 'completed'
-				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
-	)
-	// TODO: How to ask that both are on the same claim?
 
 define "Is Unilateral Mastectomy Left":
 	exists(
@@ -247,17 +271,29 @@ define "Is Absence Of Left Breast":
 
 define "Is Unilateral Mastectomy With Right Modifier":
 	exists(
-		[Procedure: "Unilateral Mastectomy Value Set"] Proc
-			where Proc.status.value = 'completed'
-				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+		[Claim] Claim
+			where exists(
+				Claim.procedure BbElem
+					with (
+						[Procedure: "Unilateral Mastectomy Value Set"] Proc
+							where Proc.status.value = 'completed'
+								and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+					) Proc1
+						such that
+							(if BbElem.procedure is FHIR.Reference
+								then (BbElem.procedure as FHIR.Reference).identifier = Proc1.identifier
+								else false)
+					with (
+						[Procedure: "Right Modifier Value Set"] Proc
+							where Proc.status.value = 'completed'
+								and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
+					) Proc2
+						such that
+							(if BbElem.procedure is FHIR.Reference
+								then (BbElem.procedure as FHIR.Reference).identifier = Proc2.identifier
+								else false)
+			)
 	)
-	and
-	exists(
-		[Procedure: "Right Modifier Value Set"] Proc
-			where Proc.status.value = 'completed'
-				and end of ChoiceToIntervalOfDT(Proc.performed) before end of "Measurement Period"
-	)
-	// TODO: How to ask that both are on the same claim?
 
 define "Is Unilateral Mastectomy Right":
 	exists(

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -117,10 +117,15 @@ define "Is In Hospice":
 	)
 	or
 	exists(
-		[Encounter: "Hospice care ambulatory"] HospiceOrderOrPerformed
-			where HospiceOrderOrPerformed.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and (PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) during "Measurement Period"
-					or PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) overlaps "Measurement Period")
+		[ProcedureRequest: "Hospice care ambulatory"] HospiceOrder
+			where HospiceOrder.status.value in { 'active', 'completed' }
+				and HospiceOrder.authoredOn.value during "Measurement Period"
+	)
+	or
+	exists(
+		[Procedure: "Hospice care ambulatory"] HospicePerformed
+			where HospicePerformed.status.value = 'completed'
+				and ChoiceToIntervalOfDT(HospicePerformed.performed) overlaps "Measurement Period"
 	)
 
 define "Is In Applicable Product Line":

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -51,6 +51,15 @@ Interval[DateTime(2015,1,1,0,0,0,0), DateTime(2016,1,1,0,0,0,0))
 
 parameter "Measurement Period" Interval<DateTime>
 
+define "First Predecessor Year":
+	Interval[start of "Measurement Period" - 1 year, start of "Measurement Period")
+
+define "Second Predecessor Year":
+	Interval[start of "Measurement Period" - 2 years, start of "Measurement Period" - 1 year)
+
+define "Third Predecessor Quarter":
+	Interval[start of "Measurement Period" - 2 years - 3 months, start of "Measurement Period" - 2 years)
+
 define "Lookback Interval 27 More Months":
 	Interval[start of "Measurement Period" - 27 months, end of "Measurement Period")
 
@@ -88,10 +97,10 @@ define "Is In Hospice":
 define "Is In Applicable Product Line":
 	case
 		when ("Product Line" ~ null) then true
-		when ("Product Line" = 'commercial') then "Is Continuous Enrollment Commercial"
-		when ("Product Line" = 'medicaid') then "Is Continuous Enrollment Medicaid"
+		when ("Product Line" = 'commercial') then "Is Continuous Enrollment"
+		when ("Product Line" = 'medicaid') then "Is Continuous Enrollment"
 		when ("Product Line" = 'medicare') then
-			("Is Continuous Enrollment Medicare"
+			("Is Continuous Enrollment"
 				and (if "Is Age 65 Plus at Start"
 					then ("Is Enrolled in Institutional SNP"
 						or "Is Living Long-Term in Institution")
@@ -99,43 +108,82 @@ define "Is In Applicable Product Line":
 		else false
 	end
 
-define "Is Continuous Enrollment Commercial":
-	true
-	// TODO: Determine continuous enrollment over the 39 month period consisting
-	// of the measurement year plus the 2 prior years plus the 3 prior months.
-	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period.
-	// Allowable gap -- No more than one gap in enrollment of up to 45 days
-	// for each full calendar year of continuous enrollment (i.e., the
-	// measurement year and the year prior to the measurement year).
-	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
-	// marked as a stub / draft / incomplete.
+define "Any Patient Coverage At Any Time":
+	[Coverage] Cov
+		where Cov.status.value in { 'active', 'cancelled' }
+	// We assume [Coverage] in Patient context implicitly has this filter:
+	// Cov.beneficiary.identifier = Patient.identifier
+	// ... and that the paitient is not connected as a policy holder or payor.
 
-define "Is Continuous Enrollment Medicaid":
-	true
-	// TODO: Determine continuous enrollment over the 39 month period consisting
-	// of the measurement year plus the 2 prior years plus the 3 prior months.
-	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period.
-	// Allowable gap -- No more than one gap in enrollment of up to 45 days
-	// for each full calendar year of continuous enrollment (i.e., the
-	// measurement year and the year prior to the measurement year).
-	// To determine continuous enrollment for a Medicaid beneficiary for
-	// whom enrollment is verified monthly, the member may not have more
-	// than a 1-month gap in coverage during each full calendar year of
-	// continuous enrollment (i.e., the measurement year and the year prior
-	// to the measurement year).
-	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
-	// marked as a stub / draft / incomplete.
+define "Product Line Organizations":
+	case "Product Line"
+		when 'commercial' then
+			[Organization] Org
+				where Org.name.value not in { 'Medicaid', 'Medicare' }
+		when 'medicaid' then
+			[Organization] Org
+				where Org.name.value in { 'Medicaid' }
+		when 'medicare' then
+			[Organization] Org
+				where Org.name.value in { 'Medicare' }
+		else List<FHIR.Organization> {}
+	end
+	// TODO: Properly determine organization(s) for the product line.
 
-define "Is Continuous Enrollment Medicare":
-	true
-	// TODO: Determine continuous enrollment over the 39 month period consisting
-	// of the measurement year plus the 2 prior years plus the 3 prior months.
-	// No gaps in enrollment are allowed the first Oct 1-Dec 31 of that 39 month period.
-	// Allowable gap -- No more than one gap in enrollment of up to 45 days
-	// for each full calendar year of continuous enrollment (i.e., the
-	// measurement year and the year prior to the measurement year).
-	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
-	// marked as a stub / draft / incomplete.
+define "Enrollment Periods":
+	collapse(
+		"Any Patient Coverage At Any Time" Cov
+			with "Product Line Organizations" Org
+				such that
+					(if Cov.payor is List<FHIR.Reference>
+						then (Cov.payor as List<FHIR.Reference>).identifier = Org.identifier
+						else false)
+			return PeriodToIntervalOfDT(Cov.period)
+	)
+	// Note: collapse() also puts the resulting intervals in order.
+
+define function "Enrollment Periods In Year"(Year Interval<DateTime>):
+	"Enrollment Periods" EnrP
+		where EnrP overlaps Year
+		return EnrP intersect Year
+
+define function "Is Continuous Enrollment In Year"(Year Interval<DateTime>):
+	case Count("Enrollment Periods In Year"(Year))
+		when 1 then (
+			(("Enrollment Periods In Year"(Year)[0] starts Year)
+				and ((difference in days between
+						end of "Enrollment Periods In Year"(Year)[0]
+						and end of Year
+					) <= 45))
+			or
+			(("Enrollment Periods In Year"(Year)[0] ends Year)
+				and ((difference in days between
+						start of "Enrollment Periods In Year"(Year)[0]
+						and start of Year
+					) <= 45))
+		)
+		when 2 then (
+			("Enrollment Periods In Year"(Year)[0] starts Year)
+				and ("Enrollment Periods In Year"(Year)[1] ends Year)
+				and ((difference in days between
+						end of "Enrollment Periods In Year"(Year)[0]
+						and start of "Enrollment Periods In Year"(Year)[1]
+					) <= 45)
+		)
+		else false
+	end
+
+define function "Is Continuous Enrollment In Quarter"(Quarter Interval<DateTime>):
+	case Count("Enrollment Periods In Year"(Quarter))
+		when 1 then ("Enrollment Periods In Year"(Quarter)[0] = Quarter)
+		else false
+	end
+
+define "Is Continuous Enrollment":
+	"Is Continuous Enrollment In Year"("Measurement Period")
+		and "Is Continuous Enrollment In Year"("First Predecessor Year")
+		and "Is Continuous Enrollment In Year"("Second Predecessor Year")
+		and "Is Continuous Enrollment In Quarter"("Third Predecessor Quarter")
 
 define "Is Age 65 Plus at Start":
 	AgeInYearsAt(start of "Measurement Period") >= 65

--- a/pages/cql/bcs-logic-2018.cql
+++ b/pages/cql/bcs-logic-2018.cql
@@ -18,14 +18,14 @@ valueset "Bilateral Mastectomy Value Set": 'TODO'
 valueset "Bilateral Modifier Value Set": 'TODO'
 valueset "History of Bilateral Mastectomy Value Set": 'TODO'
 valueset "Unilateral Mastectomy Value Set": 'TODO'
-
 valueset "Absence of Left Breast Value Set": 'TODO'
 valueset "Left Modifier Value Set": 'TODO'
 valueset "Unilateral Mastectomy Left Value Set": 'TODO'
-
 valueset "Absence of Right Breast Value Set": 'TODO'
 valueset "Right Modifier Value Set": 'TODO'
 valueset "Unilateral Mastectomy Right Value Set": 'TODO'
+
+valueset "Hospice Value Set": 'TODO'
 
 /*
 This library has a single explicit parameter which is the measurement year.
@@ -64,8 +64,11 @@ define "Is Age 52 to 74 at End":
 	AgeInYearsAt(end of "Measurement Period") between 52 and 74
 
 define "Is In Hospice":
-	false
-	// TODO: Determine properly whether the patient was in hospice during the measurement year.
+	exists(
+		[Encounter: "Hospice Value Set"] Enc
+			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+	)
 
 define "Is In Eligible Population Commercial":
 	"Is In Eligible Population"
@@ -189,7 +192,8 @@ define "Is History Of Bilateral Mastectomy":
 define "Is Unilateral Mastectomy With Bilateral Modifier":
 	exists(
 		[Claim] Claim
-			where exists(
+			where Claim.status.value = 'active'
+				and exists(
 				Claim.procedure BbElem
 					with (
 						[Procedure: "Unilateral Mastectomy Value Set"] Proc
@@ -232,7 +236,8 @@ define "Is Unilateral Mastectomy Twice Spread Two Weeks":
 define "Is Unilateral Mastectomy With Left Modifier":
 	exists(
 		[Claim] Claim
-			where exists(
+			where Claim.status.value = 'active'
+				and exists(
 				Claim.procedure BbElem
 					with (
 						[Procedure: "Unilateral Mastectomy Value Set"] Proc
@@ -272,7 +277,8 @@ define "Is Absence Of Left Breast":
 define "Is Unilateral Mastectomy With Right Modifier":
 	exists(
 		[Claim] Claim
-			where exists(
+			where Claim.status.value = 'active'
+				and exists(
 				Claim.procedure BbElem
 					with (
 						[Procedure: "Unilateral Mastectomy Value Set"] Proc
@@ -319,3 +325,6 @@ define function ChoiceToIntervalOfDT(value Choice<FHIR.dateTime, FHIR.Period>):
 		Interval[value.value, value.value]
 	else
 		Interval[value."start".value, value."end".value]
+
+define function PeriodToIntervalOfDT(value FHIR.Period):
+	Interval[value."start".value, value."end".value]

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -93,7 +93,7 @@ define "Is In Hospice":
 	exists(
 		[Encounter: "Hospice Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
 	)
 
 define "Is In Applicable Product Line":

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -23,7 +23,21 @@ valueset "Absence of Cervix Value Set": 'TODO'
 valueset "Hospice Value Set": 'TODO'
 
 /*
-This library has a single explicit parameter which is the measurement year.
+This library has an explicit parameter which is the product line.
+Recognized normal arguments are {'commercial', 'medicaid'}.
+If one of these normal arguments is given, the patient will only be
+considered to be in the Eligible Population if they have an appropriate
+continuous enrollment in that kind of medical plan.
+If instead a null argument is given, their enrollment status will have no
+effect on whether they are considered to be in the Eligible Population.
+If instead some other argument is given (an unrecognized plan type),
+the patient will unconditionally NOT be in the Eligible Population.
+*/
+
+parameter "Product Line" String
+
+/*
+This library has an explicit parameter which is the measurement year.
 While the actual parameter's type accepts all intervals, this library
 expects it will only be given arguments corresponding exactly to one whole
 calendar year, and it will not behave properly otherwise; 2015 for example:
@@ -54,6 +68,7 @@ define "Is In Eligible Population":
 	"Is Female"
 		and "Is Age 24 to 64 at End"
 		and (not "Is In Hospice")
+		and "Is In Applicable Product Line"
 
 define "Is Female":
 	Patient.gender.value = 'female'
@@ -68,9 +83,13 @@ define "Is In Hospice":
 				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
 	)
 
-define "Is In Eligible Population Commercial":
-	"Is In Eligible Population"
-		and "Is Continuous Enrollment Commercial"
+define "Is In Applicable Product Line":
+	case
+		when ("Product Line" ~ null) then true
+		when ("Product Line" = 'commercial') then "Is Continuous Enrollment Commercial"
+		when ("Product Line" = 'medicaid') then "Is Continuous Enrollment Medicaid"
+		else false
+	end
 
 define "Is Continuous Enrollment Commercial":
 	true
@@ -80,10 +99,6 @@ define "Is Continuous Enrollment Commercial":
 	// each year of continuous enrollment.
 	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
 	// marked as a stub / draft / incomplete.
-
-define "Is In Eligible Population Medicaid":
-	"Is In Eligible Population"
-		and "Is Continuous Enrollment Medicaid"
 
 define "Is Continuous Enrollment Medicaid":
 	true

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -22,6 +22,11 @@ valueset "Absence of Cervix Value Set": 'TODO'
 
 valueset "Hospice Value Set": 'TODO'
 
+valueset "Encounter Inpatient": 'urn:oid:2.16.840.1.113883.3.666.5.307' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+valueset "Discharged to Home for Hospice Care": 'urn:oid:2.16.840.1.113883.3.117.1.7.1.209' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+valueset "Discharged to Health Care Facility for Hospice Care": 'urn:oid:2.16.840.1.113883.3.117.1.7.1.207' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+valueset "Hospice care ambulatory": 'urn:oid:2.16.840.1.113762.1.4.1108.15' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+
 valueset "X Commercial Coverage Value Set": 'TODO'
 valueset "X Medicaid Coverage Value Set": 'TODO'
 valueset "X Medicare Coverage Value Set": 'TODO'
@@ -94,6 +99,23 @@ define "Is In Hospice":
 		[Encounter: "Hospice Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
 				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
+	)
+	or
+	exists(
+		[Encounter: "Encounter Inpatient"] DischargeHospice
+			where DischargeHospice.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and (CodingToCode(DischargeHospice.hospitalization.dischargeDisposition.coding)
+						in "Discharged to Home for Hospice Care"
+					or CodingToCode(DischargeHospice.hospitalization.dischargeDisposition.coding)
+						in "Discharged to Health Care Facility for Hospice Care")
+				and PeriodToIntervalOfDT(DischargeHospice.period) ends during "Measurement Period"
+	)
+	or
+	exists(
+		[Encounter: "Hospice care ambulatory"] HospiceOrderOrPerformed
+			where HospiceOrderOrPerformed.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and (PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) during "Measurement Period"
+					or PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) overlaps "Measurement Period")
 	)
 
 define "Is In Applicable Product Line":

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -112,10 +112,15 @@ define "Is In Hospice":
 	)
 	or
 	exists(
-		[Encounter: "Hospice care ambulatory"] HospiceOrderOrPerformed
-			where HospiceOrderOrPerformed.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and (PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) during "Measurement Period"
-					or PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) overlaps "Measurement Period")
+		[ProcedureRequest: "Hospice care ambulatory"] HospiceOrder
+			where HospiceOrder.status.value in { 'active', 'completed' }
+				and HospiceOrder.authoredOn.value during "Measurement Period"
+	)
+	or
+	exists(
+		[Procedure: "Hospice care ambulatory"] HospicePerformed
+			where HospicePerformed.status.value = 'completed'
+				and ChoiceToIntervalOfDT(HospicePerformed.performed) overlaps "Measurement Period"
 	)
 
 define "Is In Applicable Product Line":

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -22,6 +22,10 @@ valueset "Absence of Cervix Value Set": 'TODO'
 
 valueset "Hospice Value Set": 'TODO'
 
+valueset "X Commercial Coverage Value Set": 'TODO'
+valueset "X Medicaid Coverage Value Set": 'TODO'
+valueset "X Medicare Coverage Value Set": 'TODO'
+
 /*
 This library has an explicit parameter which is the product line.
 Recognized normal arguments are {'commercial', 'medicaid'}.
@@ -100,38 +104,25 @@ define "Is In Applicable Product Line":
 		else false
 	end
 
-define "Any Patient Coverage At Any Time":
-	[Coverage] Cov
-		where Cov.status.value in { 'active', 'cancelled' }
+define "Enrollment Periods":
+	collapse(
+		[Coverage] Cov
+			where Cov.status.value in { 'active', 'cancelled' }
+				and case "Product Line"
+					when 'commercial' then
+						CodingToCode(Cov.type.coding) in "X Commercial Coverage Value Set"
+					when 'medicaid' then
+						CodingToCode(Cov.type.coding) in "X Medicaid Coverage Value Set"
+					when 'medicare' then
+						CodingToCode(Cov.type.coding) in "X Medicare Coverage Value Set"
+					else false
+				end
+			return PeriodToIntervalOfDT(Cov.period)
+	)
 	// We assume [Coverage] in Patient context implicitly has this filter:
 	// Cov.beneficiary.identifier = Patient.identifier
 	// ... and that the paitient is not connected as a policy holder or payor.
-
-define "Product Line Organizations":
-	case "Product Line"
-		when 'commercial' then
-			[Organization] Org
-				where Org.name.value not in { 'Medicaid', 'Medicare' }
-		when 'medicaid' then
-			[Organization] Org
-				where Org.name.value in { 'Medicaid' }
-		when 'medicare' then
-			[Organization] Org
-				where Org.name.value in { 'Medicare' }
-		else List<FHIR.Organization> {}
-	end
 	// TODO: Properly determine organization(s) for the product line.
-
-define "Enrollment Periods":
-	collapse(
-		"Any Patient Coverage At Any Time" Cov
-			with "Product Line Organizations" Org
-				such that
-					(if Cov.payor is List<FHIR.Reference>
-						then (Cov.payor as List<FHIR.Reference>).identifier = Org.identifier
-						else false)
-			return PeriodToIntervalOfDT(Cov.period)
-	)
 	// Note: collapse() also puts the resulting intervals in order.
 
 define function "Enrollment Periods In Year"(Year Interval<DateTime>):
@@ -264,3 +255,12 @@ define function ChoiceToIntervalOfDT(value Choice<FHIR.dateTime, FHIR.Period>):
 
 define function PeriodToIntervalOfDT(value FHIR.Period):
 	Interval[value."start".value, value."end".value]
+
+define function CodingToCode(coding FHIR.Coding):
+	System.Code {
+		code: coding.code.value,
+		system: coding.system.value,
+		version: coding.version.value,
+		display: coding.display.value
+	}
+	// From FHIRHelpers

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -20,6 +20,8 @@ valueset "Cervical Cytology Value Set": 'TODO'
 valueset "HPV Tests Value Set": 'TODO'
 valueset "Absence of Cervix Value Set": 'TODO'
 
+valueset "Hospice Value Set": 'TODO'
+
 /*
 This library has a single explicit parameter which is the measurement year.
 While the actual parameter's type accepts all intervals, this library
@@ -60,8 +62,11 @@ define "Is Age 24 to 64 at End":
 	AgeInYearsAt(end of "Measurement Period") between 24 and 64
 
 define "Is In Hospice":
-	false
-	// TODO: Determine properly whether the patient was in hospice during the measurement year.
+	exists(
+		[Encounter: "Hospice Value Set"] Enc
+			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+	)
 
 define "Is In Eligible Population Commercial":
 	"Is In Eligible Population"
@@ -175,3 +180,6 @@ define function ChoiceToIntervalOfDT(value Choice<FHIR.dateTime, FHIR.Period>):
 		Interval[value.value, value.value]
 	else
 		Interval[value."start".value, value."end".value]
+
+define function PeriodToIntervalOfDT(value FHIR.Period):
+	Interval[value."start".value, value."end".value]

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -120,7 +120,7 @@ define "Enrollment Periods":
 			return PeriodToIntervalOfDT(Cov.period)
 	)
 	// We assume [Coverage] in Patient context implicitly has this filter:
-	// Cov.beneficiary.identifier = Patient.identifier
+	// Cov.beneficiary.identifier ~ Patient.identifier
 	// ... and that the paitient is not connected as a policy holder or payor.
 	// TODO: Properly determine organization(s) for the product line.
 	// Note: collapse() also puts the resulting intervals in order.

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -46,6 +46,15 @@ Interval[DateTime(2015,1,1,0,0,0,0), DateTime(2016,1,1,0,0,0,0))
 
 parameter "Measurement Period" Interval<DateTime>
 
+define "First Predecessor Year":
+	Interval[start of "Measurement Period" - 1 year, start of "Measurement Period")
+
+define "Second Predecessor Year":
+	Interval[start of "Measurement Period" - 2 years, start of "Measurement Period" - 1 year)
+
+define "Third Predecessor Quarter":
+	Interval[start of "Measurement Period" - 2 years - 3 months, start of "Measurement Period" - 2 years)
+
 define "Lookback Interval Two More Years":
 	Interval[start of "Measurement Period" - 2 years, end of "Measurement Period")
 
@@ -86,30 +95,87 @@ define "Is In Hospice":
 define "Is In Applicable Product Line":
 	case
 		when ("Product Line" ~ null) then true
-		when ("Product Line" = 'commercial') then "Is Continuous Enrollment Commercial"
-		when ("Product Line" = 'medicaid') then "Is Continuous Enrollment Medicaid"
+		when ("Product Line" = 'commercial') then "Is Continuous Enrollment"
+		when ("Product Line" = 'medicaid') then "Is Continuous Enrollment"
 		else false
 	end
 
-define "Is Continuous Enrollment Commercial":
-	true
-	// TODO: Determine continuous enrollment over the 3 year period consisting
-	// of the measurement year plus the 2 prior years.
-	// Allowable gap -- No more than one gap in enrollment of up to 45 days during
-	// each year of continuous enrollment.
-	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
-	// marked as a stub / draft / incomplete.
+define "Any Patient Coverage At Any Time":
+	[Coverage] Cov
+		where Cov.status.value in { 'active', 'cancelled' }
+	// We assume [Coverage] in Patient context implicitly has this filter:
+	// Cov.beneficiary.identifier = Patient.identifier
+	// ... and that the paitient is not connected as a policy holder or payor.
 
-define "Is Continuous Enrollment Medicaid":
-	true
-	// TODO: Determine continuous enrollment over the measurement year.
-	// Allowable gap -- No more than one gap in enrollment of up to 45 days during
-	// each year of continuous enrollment. To determine continuous enrollment
-	// for a Medicaid beneficiary for whom enrollment is verified monthly, the
-	// member may not have more than a 1-month gap in coverage (i.e., a member
-	// whose coverage lapses for 2 months [60 days] is not considered continuously enrolled).
-	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
-	// marked as a stub / draft / incomplete.
+define "Product Line Organizations":
+	case "Product Line"
+		when 'commercial' then
+			[Organization] Org
+				where Org.name.value not in { 'Medicaid', 'Medicare' }
+		when 'medicaid' then
+			[Organization] Org
+				where Org.name.value in { 'Medicaid' }
+		when 'medicare' then
+			[Organization] Org
+				where Org.name.value in { 'Medicare' }
+		else List<FHIR.Organization> {}
+	end
+	// TODO: Properly determine organization(s) for the product line.
+
+define "Enrollment Periods":
+	collapse(
+		"Any Patient Coverage At Any Time" Cov
+			with "Product Line Organizations" Org
+				such that
+					(if Cov.payor is List<FHIR.Reference>
+						then (Cov.payor as List<FHIR.Reference>).identifier = Org.identifier
+						else false)
+			return PeriodToIntervalOfDT(Cov.period)
+	)
+	// Note: collapse() also puts the resulting intervals in order.
+
+define function "Enrollment Periods In Year"(Year Interval<DateTime>):
+	"Enrollment Periods" EnrP
+		where EnrP overlaps Year
+		return EnrP intersect Year
+
+define function "Is Continuous Enrollment In Year"(Year Interval<DateTime>):
+	case Count("Enrollment Periods In Year"(Year))
+		when 1 then (
+			(("Enrollment Periods In Year"(Year)[0] starts Year)
+				and ((difference in days between
+						end of "Enrollment Periods In Year"(Year)[0]
+						and end of Year
+					) <= 45))
+			or
+			(("Enrollment Periods In Year"(Year)[0] ends Year)
+				and ((difference in days between
+						start of "Enrollment Periods In Year"(Year)[0]
+						and start of Year
+					) <= 45))
+		)
+		when 2 then (
+			("Enrollment Periods In Year"(Year)[0] starts Year)
+				and ("Enrollment Periods In Year"(Year)[1] ends Year)
+				and ((difference in days between
+						end of "Enrollment Periods In Year"(Year)[0]
+						and start of "Enrollment Periods In Year"(Year)[1]
+					) <= 45)
+		)
+		else false
+	end
+
+define function "Is Continuous Enrollment In Quarter"(Quarter Interval<DateTime>):
+	case Count("Enrollment Periods In Year"(Quarter))
+		when 1 then ("Enrollment Periods In Year"(Quarter)[0] = Quarter)
+		else false
+	end
+
+define "Is Continuous Enrollment":
+	"Is Continuous Enrollment In Year"("Measurement Period")
+		and "Is Continuous Enrollment In Year"("First Predecessor Year")
+		and "Is Continuous Enrollment In Year"("Second Predecessor Year")
+		and "Is Continuous Enrollment In Quarter"("Third Predecessor Quarter")
 
 /*
 Administrative Specification

--- a/pages/cql/ccs-logic-2018.cql
+++ b/pages/cql/ccs-logic-2018.cql
@@ -122,8 +122,9 @@ define "Is Cervical Cytology Plus HPV Test In Last 5 Years":
 			with "Dates of HPV Tests" WhenHPV
 				such that (((difference in days between start of WhenCC and start of WhenHPV) <= 4)
 					and AgeInYearsAt(start of WhenCC) >= 30
-					and AgeInYearsAt(start of WhenHPV) >= 30)
-			where IncludedIn(WhenCC, "Lookback Interval Four More Years")
+					and AgeInYearsAt(start of WhenHPV) >= 30
+					and IncludedIn(WhenCC, "Lookback Interval Four More Years")
+					and IncludedIn(WhenHPV, "Lookback Interval Four More Years"))
 	)
 
 define "Dates of Cervical Cytology Tests":

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -23,6 +23,9 @@ valueset "Total Colectomy Value Set": 'TODO'
 
 valueset "Hospice Value Set": 'TODO'
 
+valueset "X Institutional SNP Value Set": 'TODO'
+valueset "X Long-Term in Institution Value Set": 'TODO'
+
 /*
 This library has an explicit parameter which is the product line.
 Recognized normal arguments are {'commercial', 'medicare'}.
@@ -186,11 +189,19 @@ define "Is Age 65 Plus at Start":
 	AgeInYearsAt(start of "Measurement Period") >= 65
 
 define "Is Enrolled in Institutional SNP":
-	false
+	exists(
+		[Encounter: "X Institutional SNP Value Set"] Enc
+			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+	)
 	// TODO: Determine properly whether the patient was in SNP during the measurement year.
 
 define "Is Living Long-Term in Institution":
-	false
+	exists(
+		[Encounter: "X Long-Term in Institution Value Set"] Enc
+			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+	)
 	// TODO: Determine properly whether the patient was in LTI during the measurement year.
 
 /*

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -23,6 +23,10 @@ valueset "Total Colectomy Value Set": 'TODO'
 
 valueset "Hospice Value Set": 'TODO'
 
+valueset "X Commercial Coverage Value Set": 'TODO'
+valueset "X Medicaid Coverage Value Set": 'TODO'
+valueset "X Medicare Coverage Value Set": 'TODO'
+
 valueset "X Institutional SNP Value Set": 'TODO'
 valueset "X Long-Term in Institution Value Set": 'TODO'
 
@@ -108,38 +112,25 @@ define "Is In Applicable Product Line":
 		else false
 	end
 
-define "Any Patient Coverage At Any Time":
-	[Coverage] Cov
-		where Cov.status.value in { 'active', 'cancelled' }
+define "Enrollment Periods":
+	collapse(
+		[Coverage] Cov
+			where Cov.status.value in { 'active', 'cancelled' }
+				and case "Product Line"
+					when 'commercial' then
+						CodingToCode(Cov.type.coding) in "X Commercial Coverage Value Set"
+					when 'medicaid' then
+						CodingToCode(Cov.type.coding) in "X Medicaid Coverage Value Set"
+					when 'medicare' then
+						CodingToCode(Cov.type.coding) in "X Medicare Coverage Value Set"
+					else false
+				end
+			return PeriodToIntervalOfDT(Cov.period)
+	)
 	// We assume [Coverage] in Patient context implicitly has this filter:
 	// Cov.beneficiary.identifier = Patient.identifier
 	// ... and that the paitient is not connected as a policy holder or payor.
-
-define "Product Line Organizations":
-	case "Product Line"
-		when 'commercial' then
-			[Organization] Org
-				where Org.name.value not in { 'Medicaid', 'Medicare' }
-		when 'medicaid' then
-			[Organization] Org
-				where Org.name.value in { 'Medicaid' }
-		when 'medicare' then
-			[Organization] Org
-				where Org.name.value in { 'Medicare' }
-		else List<FHIR.Organization> {}
-	end
 	// TODO: Properly determine organization(s) for the product line.
-
-define "Enrollment Periods":
-	collapse(
-		"Any Patient Coverage At Any Time" Cov
-			with "Product Line Organizations" Org
-				such that
-					(if Cov.payor is List<FHIR.Reference>
-						then (Cov.payor as List<FHIR.Reference>).identifier = Org.identifier
-						else false)
-			return PeriodToIntervalOfDT(Cov.period)
-	)
 	// Note: collapse() also puts the resulting intervals in order.
 
 define function "Enrollment Periods In Year"(Year Interval<DateTime>):
@@ -293,3 +284,12 @@ define function ChoiceToIntervalOfDT(value Choice<FHIR.dateTime, FHIR.Period>):
 
 define function PeriodToIntervalOfDT(value FHIR.Period):
 	Interval[value."start".value, value."end".value]
+
+define function CodingToCode(coding FHIR.Coding):
+	System.Code {
+		code: coding.code.value,
+		system: coding.system.value,
+		version: coding.version.value,
+		display: coding.display.value
+	}
+	// From FHIRHelpers

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -24,7 +24,21 @@ valueset "Total Colectomy Value Set": 'TODO'
 valueset "Hospice Value Set": 'TODO'
 
 /*
-This library has a single explicit parameter which is the measurement year.
+This library has an explicit parameter which is the product line.
+Recognized normal arguments are {'commercial', 'medicare'}.
+If one of these normal arguments is given, the patient will only be
+considered to be in the Eligible Population if they have an appropriate
+continuous enrollment in that kind of medical plan.
+If instead a null argument is given, their enrollment status will have no
+effect on whether they are considered to be in the Eligible Population.
+If instead some other argument is given (an unrecognized plan type),
+the patient will unconditionally NOT be in the Eligible Population.
+*/
+
+parameter "Product Line" String
+
+/*
+This library has an explicit parameter which is the measurement year.
 While the actual parameter's type accepts all intervals, this library
 expects it will only be given arguments corresponding exactly to one whole
 calendar year, and it will not behave properly otherwise; 2015 for example:
@@ -57,6 +71,7 @@ Product lines -- Commercial, Medicare (report each product line separately).
 define "Is In Eligible Population":
 	"Is Age 51 to 75 at End"
 		and (not "Is In Hospice")
+		and "Is In Applicable Product Line"
 
 define "Is Age 51 to 75 at End":
 	AgeInYearsAt(end of "Measurement Period") between 51 and 75
@@ -68,9 +83,18 @@ define "Is In Hospice":
 				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
 	)
 
-define "Is In Eligible Population Commercial":
-	"Is In Eligible Population"
-		and "Is Continuous Enrollment Commercial"
+define "Is In Applicable Product Line":
+	case
+		when ("Product Line" ~ null) then true
+		when ("Product Line" = 'commercial') then "Is Continuous Enrollment Commercial"
+		when ("Product Line" = 'medicare') then
+			("Is Continuous Enrollment Medicare"
+				and (if "Is Age 65 Plus at Start"
+					then ("Is Enrolled in Institutional SNP"
+						or "Is Living Long-Term in Institution")
+					else false))
+		else false
+	end
 
 define "Is Continuous Enrollment Commercial":
 	true
@@ -80,14 +104,6 @@ define "Is Continuous Enrollment Commercial":
 	// each year of continuous enrollment.
 	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
 	// marked as a stub / draft / incomplete.
-
-define "Is In Eligible Population Medicare":
-	"Is In Eligible Population"
-		and "Is Continuous Enrollment Medicare"
-		and (if "Is Age 65 Plus at Start"
-			then ("Is Enrolled in Institutional SNP"
-				or "Is Living Long-Term in Institution")
-			else false)
 
 define "Is Continuous Enrollment Medicare":
 	true

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -47,6 +47,15 @@ Interval[DateTime(2015,1,1,0,0,0,0), DateTime(2016,1,1,0,0,0,0))
 
 parameter "Measurement Period" Interval<DateTime>
 
+define "First Predecessor Year":
+	Interval[start of "Measurement Period" - 1 year, start of "Measurement Period")
+
+define "Second Predecessor Year":
+	Interval[start of "Measurement Period" - 2 years, start of "Measurement Period" - 1 year)
+
+define "Third Predecessor Quarter":
+	Interval[start of "Measurement Period" - 2 years - 3 months, start of "Measurement Period" - 2 years)
+
 define "Lookback Interval Two More Years":
 	Interval[start of "Measurement Period" - 2 years, end of "Measurement Period")
 
@@ -86,9 +95,9 @@ define "Is In Hospice":
 define "Is In Applicable Product Line":
 	case
 		when ("Product Line" ~ null) then true
-		when ("Product Line" = 'commercial') then "Is Continuous Enrollment Commercial"
+		when ("Product Line" = 'commercial') then "Is Continuous Enrollment"
 		when ("Product Line" = 'medicare') then
-			("Is Continuous Enrollment Medicare"
+			("Is Continuous Enrollment"
 				and (if "Is Age 65 Plus at Start"
 					then ("Is Enrolled in Institutional SNP"
 						or "Is Living Long-Term in Institution")
@@ -96,23 +105,82 @@ define "Is In Applicable Product Line":
 		else false
 	end
 
-define "Is Continuous Enrollment Commercial":
-	true
-	// TODO: Determine continuous enrollment over the 2 year period consisting
-	// of the measurement year plus the 1 prior year.
-	// Allowable gap -- No more than one gap in enrollment of up to 45 days during
-	// each year of continuous enrollment.
-	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
-	// marked as a stub / draft / incomplete.
+define "Any Patient Coverage At Any Time":
+	[Coverage] Cov
+		where Cov.status.value in { 'active', 'cancelled' }
+	// We assume [Coverage] in Patient context implicitly has this filter:
+	// Cov.beneficiary.identifier = Patient.identifier
+	// ... and that the paitient is not connected as a policy holder or payor.
 
-define "Is Continuous Enrollment Medicare":
-	true
-	// TODO: Determine continuous enrollment over the 2 year period consisting
-	// of the measurement year plus the 1 prior year.
-	// Allowable gap -- No more than one gap in enrollment of up to 45 days during
-	// each year of continuous enrollment.
-	// See http://hl7.org/fhir/enrollmentresponse.html which is currently
-	// marked as a stub / draft / incomplete.
+define "Product Line Organizations":
+	case "Product Line"
+		when 'commercial' then
+			[Organization] Org
+				where Org.name.value not in { 'Medicaid', 'Medicare' }
+		when 'medicaid' then
+			[Organization] Org
+				where Org.name.value in { 'Medicaid' }
+		when 'medicare' then
+			[Organization] Org
+				where Org.name.value in { 'Medicare' }
+		else List<FHIR.Organization> {}
+	end
+	// TODO: Properly determine organization(s) for the product line.
+
+define "Enrollment Periods":
+	collapse(
+		"Any Patient Coverage At Any Time" Cov
+			with "Product Line Organizations" Org
+				such that
+					(if Cov.payor is List<FHIR.Reference>
+						then (Cov.payor as List<FHIR.Reference>).identifier = Org.identifier
+						else false)
+			return PeriodToIntervalOfDT(Cov.period)
+	)
+	// Note: collapse() also puts the resulting intervals in order.
+
+define function "Enrollment Periods In Year"(Year Interval<DateTime>):
+	"Enrollment Periods" EnrP
+		where EnrP overlaps Year
+		return EnrP intersect Year
+
+define function "Is Continuous Enrollment In Year"(Year Interval<DateTime>):
+	case Count("Enrollment Periods In Year"(Year))
+		when 1 then (
+			(("Enrollment Periods In Year"(Year)[0] starts Year)
+				and ((difference in days between
+						end of "Enrollment Periods In Year"(Year)[0]
+						and end of Year
+					) <= 45))
+			or
+			(("Enrollment Periods In Year"(Year)[0] ends Year)
+				and ((difference in days between
+						start of "Enrollment Periods In Year"(Year)[0]
+						and start of Year
+					) <= 45))
+		)
+		when 2 then (
+			("Enrollment Periods In Year"(Year)[0] starts Year)
+				and ("Enrollment Periods In Year"(Year)[1] ends Year)
+				and ((difference in days between
+						end of "Enrollment Periods In Year"(Year)[0]
+						and start of "Enrollment Periods In Year"(Year)[1]
+					) <= 45)
+		)
+		else false
+	end
+
+define function "Is Continuous Enrollment In Quarter"(Quarter Interval<DateTime>):
+	case Count("Enrollment Periods In Year"(Quarter))
+		when 1 then ("Enrollment Periods In Year"(Quarter)[0] = Quarter)
+		else false
+	end
+
+define "Is Continuous Enrollment":
+	"Is Continuous Enrollment In Year"("Measurement Period")
+		and "Is Continuous Enrollment In Year"("First Predecessor Year")
+		and "Is Continuous Enrollment In Year"("Second Predecessor Year")
+		and "Is Continuous Enrollment In Quarter"("Third Predecessor Quarter")
 
 define "Is Age 65 Plus at Start":
 	AgeInYearsAt(start of "Measurement Period") >= 65

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -21,6 +21,8 @@ valueset "FIT-DNA Value Set": 'TODO'
 valueset "Colorectal Cancer Value Set": 'TODO'
 valueset "Total Colectomy Value Set": 'TODO'
 
+valueset "Hospice Value Set": 'TODO'
+
 /*
 This library has a single explicit parameter which is the measurement year.
 While the actual parameter's type accepts all intervals, this library
@@ -60,8 +62,11 @@ define "Is Age 51 to 75 at End":
 	AgeInYearsAt(end of "Measurement Period") between 51 and 75
 
 define "Is In Hospice":
-	false
-	// TODO: Determine properly whether the patient was in hospice during the measurement year.
+	exists(
+		[Encounter: "Hospice Value Set"] Enc
+			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+	)
 
 define "Is In Eligible Population Commercial":
 	"Is In Eligible Population"
@@ -190,3 +195,6 @@ define function ChoiceToIntervalOfDT(value Choice<FHIR.dateTime, FHIR.Period>):
 		Interval[value.value, value.value]
 	else
 		Interval[value."start".value, value."end".value]
+
+define function PeriodToIntervalOfDT(value FHIR.Period):
+	Interval[value."start".value, value."end".value]

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -23,6 +23,11 @@ valueset "Total Colectomy Value Set": 'TODO'
 
 valueset "Hospice Value Set": 'TODO'
 
+valueset "Encounter Inpatient": 'urn:oid:2.16.840.1.113883.3.666.5.307' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+valueset "Discharged to Home for Hospice Care": 'urn:oid:2.16.840.1.113883.3.117.1.7.1.209' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+valueset "Discharged to Health Care Facility for Hospice Care": 'urn:oid:2.16.840.1.113883.3.117.1.7.1.207' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+valueset "Hospice care ambulatory": 'urn:oid:2.16.840.1.113762.1.4.1108.15' version 'urn:hl7:version:eCQM%20Update%202017-05-05'
+
 valueset "X Commercial Coverage Value Set": 'TODO'
 valueset "X Medicaid Coverage Value Set": 'TODO'
 valueset "X Medicare Coverage Value Set": 'TODO'
@@ -97,6 +102,23 @@ define "Is In Hospice":
 		[Encounter: "Hospice Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
 				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
+	)
+	or
+	exists(
+		[Encounter: "Encounter Inpatient"] DischargeHospice
+			where DischargeHospice.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and (CodingToCode(DischargeHospice.hospitalization.dischargeDisposition.coding)
+						in "Discharged to Home for Hospice Care"
+					or CodingToCode(DischargeHospice.hospitalization.dischargeDisposition.coding)
+						in "Discharged to Health Care Facility for Hospice Care")
+				and PeriodToIntervalOfDT(DischargeHospice.period) ends during "Measurement Period"
+	)
+	or
+	exists(
+		[Encounter: "Hospice care ambulatory"] HospiceOrderOrPerformed
+			where HospiceOrderOrPerformed.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
+				and (PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) during "Measurement Period"
+					or PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) overlaps "Measurement Period")
 	)
 
 define "Is In Applicable Product Line":

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -128,7 +128,7 @@ define "Enrollment Periods":
 			return PeriodToIntervalOfDT(Cov.period)
 	)
 	// We assume [Coverage] in Patient context implicitly has this filter:
-	// Cov.beneficiary.identifier = Patient.identifier
+	// Cov.beneficiary.identifier ~ Patient.identifier
 	// ... and that the paitient is not connected as a policy holder or payor.
 	// TODO: Properly determine organization(s) for the product line.
 	// Note: collapse() also puts the resulting intervals in order.

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -96,7 +96,7 @@ define "Is In Hospice":
 	exists(
 		[Encounter: "Hospice Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
 	)
 
 define "Is In Applicable Product Line":
@@ -183,7 +183,7 @@ define "Is Enrolled in Institutional SNP":
 	exists(
 		[Encounter: "X Institutional SNP Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
 	)
 	// TODO: Determine properly whether the patient was in SNP during the measurement year.
 
@@ -191,7 +191,7 @@ define "Is Living Long-Term in Institution":
 	exists(
 		[Encounter: "X Long-Term in Institution Value Set"] Enc
 			where Enc.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and Overlaps(PeriodToIntervalOfDT(Enc.period), "Measurement Period")
+				and PeriodToIntervalOfDT(Enc.period) overlaps "Measurement Period"
 	)
 	// TODO: Determine properly whether the patient was in LTI during the measurement year.
 

--- a/pages/cql/col-logic-2018.cql
+++ b/pages/cql/col-logic-2018.cql
@@ -115,10 +115,15 @@ define "Is In Hospice":
 	)
 	or
 	exists(
-		[Encounter: "Hospice care ambulatory"] HospiceOrderOrPerformed
-			where HospiceOrderOrPerformed.status.value in { 'planned', 'arrived', 'triaged', 'in-progress', 'onleave', 'finished' }
-				and (PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) during "Measurement Period"
-					or PeriodToIntervalOfDT(HospiceOrderOrPerformed.period) overlaps "Measurement Period")
+		[ProcedureRequest: "Hospice care ambulatory"] HospiceOrder
+			where HospiceOrder.status.value in { 'active', 'completed' }
+				and HospiceOrder.authoredOn.value during "Measurement Period"
+	)
+	or
+	exists(
+		[Procedure: "Hospice care ambulatory"] HospicePerformed
+			where HospicePerformed.status.value = 'completed'
+				and ChoiceToIntervalOfDT(HospicePerformed.performed) overlaps "Measurement Period"
 	)
 
 define "Is In Applicable Product Line":


### PR DESCRIPTION
This adds the last missing BCS measure-specific logic, the administrative exclusion on bilateral mastectomy.

This logic addition has a minor TODO about how to test whether a left/right modifier is on the same claim as the base unilateral mastectomy procedure; meanwhile we simply test that both the base procedure and the modifier exist.
